### PR TITLE
feat(azure-login): Add optional object_id attribute to mssql_user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -45,10 +45,11 @@ The `login` block supports the following arguments:
 
 * `username` - (Required) The username of the SQL Server login. Can also be sourced from the `MSSQL_USERNAME` environment variable.
 * `password` - (Required) The password of the SQL Server login. Can also be sourced from the `MSSQL_PASSWORD` environment variable.
+* `object_id` - (Optional) The object id of the external username. Only used in azure_login auth context when AAD role delegation to sql server identity is not possible.
 
 The `azure_login` block supports the following arguments:
 
-* `tenant_id` - (Required) The tanant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
+* `tenant_id` - (Required) The tenant ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_TENANT_ID` environment variable.
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
 

--- a/mssql/const.go
+++ b/mssql/const.go
@@ -5,6 +5,7 @@ const (
   databaseProp             = "database"
   principalIdProp          = "principal_id"
   usernameProp             = "username"
+  objectIdProp             = "object_id"
   passwordProp             = "password"
   clientIdProp             = "client_id"
   authenticationTypeProp   = "authentication_type"

--- a/mssql/model/user.go
+++ b/mssql/model/user.go
@@ -3,6 +3,7 @@ package model
 type User struct {
   PrincipalID     int64
   Username        string
+  ObjectId        string
   LoginName       string
   Password        string
   AuthType        string

--- a/mssql/resource_user.go
+++ b/mssql/resource_user.go
@@ -38,6 +38,11 @@ func resourceUser() *schema.Resource {
         Required: true,
         ForceNew: true,
       },
+      objectIdProp: {
+        Type:     schema.TypeString,
+        Optional: true,
+        ForceNew: true,
+      },
       loginNameProp: {
         Type:     schema.TypeString,
         Optional: true,
@@ -95,6 +100,7 @@ func resourceUserCreate(ctx context.Context, data *schema.ResourceData, meta int
 
   database := data.Get(databaseProp).(string)
   username := data.Get(usernameProp).(string)
+  objectId := data.Get(objectIdProp).(string)
   loginName := data.Get(loginNameProp).(string)
   password := data.Get(passwordProp).(string)
   defaultSchema := data.Get(defaultSchemaProp).(string)
@@ -123,6 +129,7 @@ func resourceUserCreate(ctx context.Context, data *schema.ResourceData, meta int
 
   user := &model.User{
     Username:        username,
+    ObjectId:        objectId,
     LoginName:       loginName,
     Password:        password,
     AuthType:        authType,

--- a/sql/user.go
+++ b/sql/user.go
@@ -104,7 +104,14 @@ func (c *Connector) CreateUser(ctx context.Context, database string, user *model
             BEGIN
               IF @@VERSION LIKE 'Microsoft SQL Azure%'
                 BEGIN
-                  SET @stmt = 'CREATE USER ' + QuoteName(@username) + ' FROM EXTERNAL PROVIDER'
+                  IF @objectId != ''
+                    BEGIN
+                      SET @stmt = 'CREATE USER ' + QuoteName(@username) + ' WITH SID=' + CONVERT(varchar(64), CAST(CAST(@objectId AS UNIQUEIDENTIFIER) AS VARBINARY(16)), 1) + ', TYPE=E'
+                    END
+                  ELSE
+                    BEGIN
+                      SET @stmt = 'CREATE USER ' + QuoteName(@username) + ' FROM EXTERNAL PROVIDER'
+                  END
                 END
               ELSE
                 BEGIN
@@ -137,6 +144,7 @@ func (c *Connector) CreateUser(ctx context.Context, database string, user *model
     ExecContext(ctx, cmd,
       sql.Named("database", database),
       sql.Named("username", user.Username),
+      sql.Named("objectId", user.ObjectId),
       sql.Named("loginName", user.LoginName),
       sql.Named("password", user.Password),
       sql.Named("authType", user.AuthType),


### PR DESCRIPTION
This code is a workaround based on : https://github.com/MicrosoftDocs/sql-docs/issues/2323#issuecomment-652907219

When it is not possible to give AD role : Directory Readers to the Sql Server Identity or an AD Group, we can't use external provider.

While waiting for new Sql Server feature : https://github.com/MicrosoftDocs/sql-docs/issues/2323#issuecomment-791718677, here is a feature to be able to use external provider 