### PR TITLE
Only create string_split if DB level doesn't have it

### DIFF
--- a/sql/user.go
+++ b/sql/user.go
@@ -120,7 +120,7 @@ func (c *Connector) CreateUser(ctx context.Context, database string, user *model
                               'DEFAULT_LANGUAGE = ' + Coalesce(QuoteName(@language), 'NONE')
                 END
             END
-          IF objectproperty(object_id('String_Split'), 'isProcedure') IS NULL
+          IF exists (select compatibility_level FROM sys.databases where name = db_name() and compatibility_level < 130)
           BEGIN
               DECLARE @sql NVARCHAR(MAX);
               SET @sql = N'Create FUNCTION [dbo].[String_Split]
@@ -191,7 +191,7 @@ func (c *Connector) UpdateUser(ctx context.Context, database string, user *model
             BEGIN
               SET @stmt = @stmt + ', DEFAULT_LANGUAGE = ' + Coalesce(QuoteName(@language), 'NONE')
             END
-          IF objectproperty(object_id('String_Split'), 'isProcedure') IS NULL
+          IF exists (select compatibility_level FROM sys.databases where name = db_name() and compatibility_level < 130)
           BEGIN
               DECLARE @sql NVARCHAR(MAX);
               SET @sql = N'Create FUNCTION [dbo].[String_Split]


### PR DESCRIPTION
Fixes #23

Rather than creating the split function in all databases, only create it if it isn't present. This avoids
1. Unnecessary 3rd party code in a database
2. A race condition where 2 users being created at the same time result in the second one failing due to the split function being attempted to be created twice.

NB: I haven't compiled this code but have tested the logic in a SQL Azure database and adjusting the compatibility level.

```sql
alter database test set compatibility_level = 120
go
if exists (select compatibility_level FROM sys.databases where name = db_name() and compatibility_level < 130)
begin
	print 'will fail'
	SELECT value FROM STRING_SPLIT('1,2', ',')
end

alter database test set compatibility_level = 150
go
if exists (select compatibility_level FROM sys.databases where name = db_name() and compatibility_level < 130)
begin
	print ''
end
else
begin
	print 'will work'
	SELECT value FROM STRING_SPLIT('1,2', ',')
end
```
