### PR TITLE
Fix typo: `Dictionary Reader` -> `Directory Readers`

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -19,7 +19,7 @@ resource "mssql_user" "example" {
 }
 ```
 
-> Note that in order to create an external user referencing an Azure AD entity (user, application), the Azure SQL Server needs to be a member of an Azure AD group assigned the Azure AD role `Dictionary Reader`. If it is not possible to give the Azure SQL Server this role (through the group), you can use the `object id` of the Azure AD entity instead.
+> Note that in order to create an external user referencing an Azure AD entity (user, application), the Azure SQL Server needs to be a member of an Azure AD group assigned the Azure AD role `Directory Readers`. If it is not possible to give the Azure SQL Server this role (through the group), you can use the `object id` of the Azure AD entity instead.
 
 ## Argument Reference
 


### PR DESCRIPTION
There was a typo in the group name, it should be Directory Readers as shown [here](https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#directory-readers)