### PR TITLE
Check if String_Split already exists

### DIFF
--- a/sql/user.go
+++ b/sql/user.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Connector) GetUser(ctx context.Context, database, username string) (*model.User, error) {
-	cmd := `DECLARE @stmt nvarchar(max)
+  cmd := `DECLARE @stmt nvarchar(max)
           IF @@VERSION LIKE 'Microsoft SQL Azure%'
             BEGIN
               SET @stmt = 'WITH CTE_Roles (principal_id, role_principal_id) AS ' +
@@ -42,49 +42,49 @@ func (c *Connector) GetUser(ctx context.Context, database, username string) (*mo
                           'GROUP BY p.principal_id, p.name, p.authentication_type_desc, p.default_schema_name, p.default_language_name, p.sid, sl.name'
             END
           EXEC (@stmt)`
-	var (
-		user  model.User
-		sid   []byte
-		roles string
-	)
-	err := c.
-		setDatabase(&database).
-		QueryRowContext(ctx, cmd,
-			func(r *sql.Row) error {
-				return r.Scan(&user.PrincipalID, &user.Username, &user.AuthType, &user.DefaultSchema, &user.DefaultLanguage, &sid, &user.SIDStr, &user.LoginName, &roles)
-			},
-			sql.Named("database", database),
-			sql.Named("username", username),
-		)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if user.AuthType == "INSTANCE" && user.LoginName == "" {
-		cmd = "SELECT name FROM [sys].[sql_logins] WHERE sid = @sid"
-		c.Database = "master"
-		err = c.QueryRowContext(ctx, cmd,
-			func(r *sql.Row) error {
-				return r.Scan(&user.LoginName)
-			},
-			sql.Named("sid", sid),
-		)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if roles == "" {
-		user.Roles = make([]string, 0)
-	} else {
-		user.Roles = strings.Split(roles, ",")
-	}
-	return &user, nil
+  var (
+    user  model.User
+    sid   []byte
+    roles string
+  )
+  err := c.
+    setDatabase(&database).
+    QueryRowContext(ctx, cmd,
+      func(r *sql.Row) error {
+        return r.Scan(&user.PrincipalID, &user.Username, &user.AuthType, &user.DefaultSchema, &user.DefaultLanguage, &sid, &user.SIDStr, &user.LoginName, &roles)
+      },
+      sql.Named("database", database),
+      sql.Named("username", username),
+    )
+  if err != nil {
+    if err == sql.ErrNoRows {
+      return nil, nil
+    }
+    return nil, err
+  }
+  if user.AuthType == "INSTANCE" && user.LoginName == "" {
+    cmd = "SELECT name FROM [sys].[sql_logins] WHERE sid = @sid"
+    c.Database = "master"
+    err = c.QueryRowContext(ctx, cmd,
+      func(r *sql.Row) error {
+        return r.Scan(&user.LoginName)
+      },
+      sql.Named("sid", sid),
+    )
+    if err != nil {
+      return nil, err
+    }
+  }
+  if roles == "" {
+    user.Roles = make([]string, 0)
+  } else {
+    user.Roles = strings.Split(roles, ",")
+  }
+  return &user, nil
 }
 
 func (c *Connector) CreateUser(ctx context.Context, database string, user *model.User) error {
-	cmd := `DECLARE @stmt nvarchar(max)
+  cmd := `DECLARE @stmt nvarchar(max)
           DECLARE @language nvarchar(max) = @defaultLanguage
           IF @language = '' SET @language = NULL
           IF @authType = 'INSTANCE'
@@ -162,30 +162,30 @@ func (c *Connector) CreateUser(ctx context.Context, database string, user *model
                       'CLOSE role_cur;' +
                       'DEALLOCATE role_cur;'
           EXEC (@stmt)`
-	if user.AuthType != "EXTERNAL" {
-		// External users do not have a server login
-		_, err := c.GetLogin(ctx, user.LoginName)
-		if err != nil {
-			return err
-		}
-	}
-	return c.
-		setDatabase(&database).
-		ExecContext(ctx, cmd,
-			sql.Named("database", database),
-			sql.Named("username", user.Username),
-			sql.Named("objectId", user.ObjectId),
-			sql.Named("loginName", user.LoginName),
-			sql.Named("password", user.Password),
-			sql.Named("authType", user.AuthType),
-			sql.Named("defaultSchema", user.DefaultSchema),
-			sql.Named("defaultLanguage", user.DefaultLanguage),
-			sql.Named("roles", strings.Join(user.Roles, ",")),
-		)
+  if user.AuthType != "EXTERNAL" {
+    // External users do not have a server login
+    _, err := c.GetLogin(ctx, user.LoginName)
+    if err != nil {
+      return err
+    }
+  }
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd,
+      sql.Named("database", database),
+      sql.Named("username", user.Username),
+      sql.Named("objectId", user.ObjectId),
+      sql.Named("loginName", user.LoginName),
+      sql.Named("password", user.Password),
+      sql.Named("authType", user.AuthType),
+      sql.Named("defaultSchema", user.DefaultSchema),
+      sql.Named("defaultLanguage", user.DefaultLanguage),
+      sql.Named("roles", strings.Join(user.Roles, ",")),
+    )
 }
 
 func (c *Connector) UpdateUser(ctx context.Context, database string, user *model.User) error {
-	cmd := `DECLARE @stmt nvarchar(max)
+  cmd := `DECLARE @stmt nvarchar(max)
           SET @stmt = 'ALTER USER ' + QuoteName(@username) + ' '
           DECLARE @language nvarchar(max) = @defaultLanguage
           IF @language = '' SET @language = NULL
@@ -247,31 +247,31 @@ func (c *Connector) UpdateUser(ctx context.Context, database string, user *model
                       'CLOSE add_role_cur;' +
                       'DEALLOCATE add_role_cur;'
           EXEC (@stmt)`
-	return c.
-		setDatabase(&database).
-		ExecContext(ctx, cmd,
-			sql.Named("database", database),
-			sql.Named("username", user.Username),
-			sql.Named("defaultSchema", user.DefaultSchema),
-			sql.Named("defaultLanguage", user.DefaultLanguage),
-			sql.Named("roles", strings.Join(user.Roles, ",")),
-		)
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd,
+      sql.Named("database", database),
+      sql.Named("username", user.Username),
+      sql.Named("defaultSchema", user.DefaultSchema),
+      sql.Named("defaultLanguage", user.DefaultLanguage),
+      sql.Named("roles", strings.Join(user.Roles, ",")),
+    )
 }
 
 func (c *Connector) DeleteUser(ctx context.Context, database, username string) error {
-	cmd := `DECLARE @stmt nvarchar(max)
+  cmd := `DECLARE @stmt nvarchar(max)
           SET @stmt = 'IF EXISTS (SELECT 1 FROM ' + QuoteName(@database) + '.[sys].[database_principals] WHERE [name] = ' + QuoteName(@username, '''') + ') ' +
                       'DROP USER ' + QuoteName(@username)
           EXEC (@stmt)`
-	return c.
-		setDatabase(&database).
-		ExecContext(ctx, cmd, sql.Named("database", database), sql.Named("username", username))
+  return c.
+    setDatabase(&database).
+    ExecContext(ctx, cmd, sql.Named("database", database), sql.Named("username", username))
 }
 
 func (c *Connector) setDatabase(database *string) *Connector {
-	if *database == "" {
-		*database = "master"
-	}
-	c.Database = *database
-	return c
+  if *database == "" {
+    *database = "master"
+  }
+  c.Database = *database
+  return c
 }


### PR DESCRIPTION
Potential fix for #31 

When multiple `mssql_user` resources are created using this provider, the compatibility level is less than 130, this seems to be an issue as the provider tried to define the custom function multiple times. I am testing on Azure currently (which seems to have compatibility level 150) so I cannot reliably test if this really solves it.

As the user reported the issue didn't exist on `0.2.3` this seems like a safe addition and shouldn't break anything.