### PR TITLE
Support azuread style "federated" authentication

### DIFF
--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -30,6 +30,8 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
 
@@ -42,7 +44,11 @@ The `azure_login` block supports the following arguments:
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
 
--> Only one of `login` or `azure_login` can be specified. If neither is specified and both are sourced from environment variables, `azure_login` will be preferred.
+The `azuread_managed_identity_auth` block supports the following arguments:
+
+* `user_id` - (Optional) Id of a user-assigned managed identity to assume. Omitting this property instructs the provider to assume a system-assigned managed identity.
+
+-> Only one of `login`, `azure_login`, `azuread_default_chain_auth` and `azuread_managed_identity_auth` can be specified.
 
 ## Attribute Reference
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -42,6 +42,8 @@ The `server` block supports the following arguments:
 * `port` - (Optional) The port of the SQL Server. Defaults to `1433`. Changing this forces a new resource to be created.
 * `login` - (Optional) SQL Server login for managing the database resources. The attributes supported in the `login` block is detailed below.
 * `azure_login` - (Optional) Azure AD login for managing the database resources. The attributes supported in the `azure_login` block is detailed below.
+* `azuread_default_chain_auth` - (Optional) Use a chain of strategies for authenticating when managing the database resources. This auth strategy is very similar to how the Azure CLI authenticates. For more information, see [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-go/wiki/Set-up-Your-Environment-for-Authentication#configure-defaultazurecredential). This block has no attributes.
+* `azuread_managed_identity_auth` - (Optional) Use a managed identity for authenticating when managing the database resources. This is mainly useful for specifying a user-assigned managed identity. The attributes supported in the `azuread_managed_identity_auth` block is detailed below.
 
 The `login` block supports the following arguments:
 
@@ -55,7 +57,11 @@ The `azure_login` block supports the following arguments:
 * `client_id` - (Required) The client ID of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_ID` environment variable.
 * `client_secret` - (Required) The client secret of the principal used to login to the SQL Server. Can also be sourced from the `MSSQL_CLIENT_SECRET` environment variable.
 
--> Only one of `login` or `azure_login` can be specified. If neither is specified and both are sourced from environment variables, `azure_login` will be preferred.
+The `azuread_managed_identity_auth` block supports the following arguments:
+
+* `user_id` - (Optional) Id of a user-assigned managed identity to assume. Omitting this property instructs the provider to assume a system-assigned managed identity.
+
+-> Only one of `login`, `azure_login`, `azuread_default_chain_auth` and `azuread_managed_identity_auth` can be specified.
 
 ## Attribute Reference
 

--- a/examples/fedauth/main.tf
+++ b/examples/fedauth/main.tf
@@ -1,0 +1,136 @@
+terraform {
+  required_version = "~> 0.13"
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 1.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.99.0"
+    }
+    mssql = {
+      source  = "betr.io/betr/mssql"
+      version = "0.2.6"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.6.0"
+    }
+  }
+}
+
+provider "azuread" {}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "mssql" {
+  debug = "true"
+}
+
+provider "random" {}
+
+variable "prefix" {
+  description = "A prefix used when naming Azure resources"
+  type        = string
+}
+
+variable "sql_servers_group" {
+  description = "The name of an Azure AD group assigned the role 'Directory Reader'. The Azure SQL Server will be added to this group to enable external logins."
+  type        = string
+  default     = "SQL Servers"
+}
+
+variable "location" {
+  description = "The location of the Azure resources."
+  type        = string
+  default     = "East US"
+}
+
+variable "local_ip_addresses" {
+  description = "The external IP addresses of the machines running the acceptance tests. This is necessary to allow access to the Azure SQL Server resource."
+  type        = list(string)
+}
+
+#
+# Creates an Azure SQL Database running in a temporary resource group on Azure.
+#
+
+# Random names and secrets
+resource "random_string" "random" {
+  length  = 16
+  upper   = false
+  special = false
+}
+
+locals {
+  prefix = "${var.prefix}-${substr(random_string.random.result, 0, 4)}"
+}
+
+data "azuread_client_config" "current" {}
+
+# Temporary resource group
+resource "azurerm_resource_group" "rg" {
+  name     = "${lower(var.prefix)}-${random_string.random.result}"
+  location = var.location
+}
+
+# An Azure SQL Server
+resource "azurerm_mssql_server" "sql_server" {
+  name                = "${lower(local.prefix)}-sql-server"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  version             = "12.0"
+
+  azuread_administrator {
+    tenant_id                   = data.azuread_client_config.current.tenant_id
+    object_id                   = data.azuread_client_config.current.client_id
+    login_username              = "superuser"
+    azuread_authentication_only = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_sql_firewall_rule" "sql_server_fw_rule" {
+  count               = length(var.local_ip_addresses)
+  name                = "AllowIP ${count.index}"
+  resource_group_name = azurerm_mssql_server.sql_server.resource_group_name
+  server_name         = azurerm_mssql_server.sql_server.name
+  start_ip_address    = var.local_ip_addresses[count.index]
+  end_ip_address      = var.local_ip_addresses[count.index]
+}
+
+# The Azure SQL Database used in tests
+resource "azurerm_mssql_database" "db" {
+  name      = "testdb"
+  server_id = azurerm_mssql_server.sql_server.id
+  sku_name  = "Basic"
+}
+
+resource "time_sleep" "wait_15_seconds" {
+  depends_on = [azurerm_mssql_database.db]
+
+  create_duration = "15s"
+}
+
+#
+# Creates a login and user from Azure AD in the SQL Server
+#
+
+resource "mssql_user" "external" {
+  server {
+    host = azurerm_mssql_server.sql_server.fully_qualified_domain_name
+    azuread_default_chain_auth {}
+  }
+  database = azurerm_mssql_database.db.name
+  username = "someone@foobar.onmicrosoft.com"
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,9 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
@@ -58,6 +61,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0 h1:lhSJz9RMbJcTgxifR1hUNJnn6CNYtbgEDtQV22/9RBA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0 h1:OYa9vmRX2XC5GXRAzeggG12sF/z5D9Ahtdm9EJ00WN4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI41IfPoLFiFkLtb+bmGjT0=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -212,6 +215,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/mssql/resource_user_import_test.go
+++ b/mssql/resource_user_import_test.go
@@ -14,7 +14,7 @@ func TestAccUser_Local_BasicImport(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "test_import", false, map[string]interface{}{"username": "user_import", "login_name": "user_import", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "test_import", "login", map[string]interface{}{"username": "user_import", "login_name": "user_import", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           testAccCheckUserExists("mssql_user.test_import"),
         ),

--- a/mssql/resource_user_test.go
+++ b/mssql/resource_user_test.go
@@ -1,11 +1,12 @@
 package mssql
 
 import (
-  "fmt"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-  "os"
-  "testing"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccUser_Local_Instance(t *testing.T) {
@@ -16,7 +17,7 @@ func TestAccUser_Local_Instance(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "instance", false, map[string]interface{}{"username": "instance", "login_name": "user_instance", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "instance", "login", map[string]interface{}{"username": "instance", "login_name": "user_instance", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           testAccCheckUserExists("mssql_user.instance"),
           testAccCheckDatabaseUserWorks("mssql_user.instance", "user_instance", "valueIsH8kd$¡"),
@@ -50,7 +51,7 @@ func TestAccUser_Azure_Instance(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "instance", true, map[string]interface{}{"database": "testdb", "username": "instance", "login_name": "user_instance", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "instance", "azure", map[string]interface{}{"database": "testdb", "username": "instance", "login_name": "user_instance", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           testAccCheckUserExists("mssql_user.instance"),
           testAccCheckDatabaseUserWorks("mssql_user.instance", "user_instance", "valueIsH8kd$¡"),
@@ -85,7 +86,7 @@ func TestAccUser_Azure_Database(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "database", true, map[string]interface{}{"database": "testdb", "username": "database_user", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "database", "azure", map[string]interface{}{"database": "testdb", "username": "database_user", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           testAccCheckUserExists("mssql_user.database"),
           testAccCheckDatabaseUserWorks("mssql_user.database", "database_user", "valueIsH8kd$¡"),
@@ -105,8 +106,52 @@ func TestAccUser_Azure_Database(t *testing.T) {
           resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.0.tenant_id", os.Getenv("MSSQL_TENANT_ID")),
           resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.0.client_id", os.Getenv("MSSQL_CLIENT_ID")),
           resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.0.client_secret", os.Getenv("MSSQL_CLIENT_SECRET")),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_default_chain_auth.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_managed_identity_auth.#", "0"),
           resource.TestCheckResourceAttr("mssql_user.database", "server.0.login.#", "0"),
           resource.TestCheckResourceAttrSet("mssql_user.database", "principal_id"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccUser_AzureadChain_Database(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckUser(t, "database", "fedauth", map[string]interface{}{"database": "testdb", "username": "database_user", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckUserExists("mssql_user.database"),
+          testAccCheckDatabaseUserWorks("mssql_user.database", "database_user", "valueIsH8kd$¡"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_default_chain_auth.#", "1"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_managed_identity_auth.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.login.#", "0"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccUser_AzureadMSI_Database(t *testing.T) {
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckUser(t, "database", "msi", map[string]interface{}{"database": "testdb", "username": "database_user", "password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckUserExists("mssql_user.database"),
+          testAccCheckDatabaseUserWorks("mssql_user.database", "database_user", "valueIsH8kd$¡"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_default_chain_auth.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_managed_identity_auth.#", "1"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.login.#", "0"),
         ),
       },
     },
@@ -124,7 +169,7 @@ func TestAccUser_Azure_External(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "database", true, map[string]interface{}{"database": "testdb", "username": clientUser, "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "database", "azure", map[string]interface{}{"database": "testdb", "username": clientUser, "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           testAccCheckUserExists("mssql_user.database"),
           testAccCheckExternalUserWorks("mssql_user.database", tenantId, clientId, clientSecret),
@@ -152,6 +197,56 @@ func TestAccUser_Azure_External(t *testing.T) {
   })
 }
 
+func TestAccUser_AzureadChain_External(t *testing.T) {
+  tenantId := os.Getenv("MSSQL_TENANT_ID")
+  clientId := os.Getenv("TF_ACC_AZURE_USER_CLIENT_ID")
+  clientUser := os.Getenv("TF_ACC_AZURE_USER_CLIENT_USER")
+  clientSecret := os.Getenv("TF_ACC_AZURE_USER_CLIENT_SECRET")
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckUser(t, "database", "fedauth", map[string]interface{}{"database": "testdb", "username": clientUser, "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckUserExists("mssql_user.database"),
+          testAccCheckExternalUserWorks("mssql_user.database", tenantId, clientId, clientSecret),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_default_chain_auth.#", "1"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_managed_identity_auth.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.login.#", "0"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccUser_AzureadMSI_External(t *testing.T) {
+  tenantId := os.Getenv("MSSQL_TENANT_ID")
+  clientId := os.Getenv("TF_ACC_AZURE_USER_CLIENT_ID")
+  clientUser := os.Getenv("TF_ACC_AZURE_USER_CLIENT_USER")
+  clientSecret := os.Getenv("TF_ACC_AZURE_USER_CLIENT_SECRET")
+  resource.Test(t, resource.TestCase{
+    PreCheck:          func() { testAccPreCheck(t) },
+    ProviderFactories: testAccProviders,
+    CheckDestroy:      func(state *terraform.State) error { return testAccCheckUserDestroy(state) },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCheckUser(t, "database", "msi", map[string]interface{}{"database": "testdb", "username": clientUser, "roles": "[\"db_owner\"]"}),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckUserExists("mssql_user.database"),
+          testAccCheckExternalUserWorks("mssql_user.database", tenantId, clientId, clientSecret),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azure_login.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_default_chain_auth.#", "0"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.azuread_managed_identity_auth.#", "1"),
+          resource.TestCheckResourceAttr("mssql_user.database", "server.0.login.#", "0"),
+        ),
+      },
+    },
+  })
+}
+
 func TestAccUser_Local_Update_DefaultSchema(t *testing.T) {
   resource.Test(t, resource.TestCase{
     PreCheck:          func() { testAccPreCheck(t) },
@@ -160,7 +255,7 @@ func TestAccUser_Local_Update_DefaultSchema(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_schema", "dbo"),
           testAccCheckUserExists("mssql_user.update", Check{"default_schema", "==", "dbo"}),
@@ -168,7 +263,7 @@ func TestAccUser_Local_Update_DefaultSchema(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_schema": "sys"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_schema": "sys"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_schema", "sys"),
           testAccCheckUserExists("mssql_user.update", Check{"default_schema", "==", "sys"}),
@@ -187,7 +282,7 @@ func TestAccUser_Local_Update_DefaultLanguage(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_language", ""),
           testAccCheckUserExists("mssql_user.update", Check{"default_language", "==", ""}),
@@ -195,7 +290,7 @@ func TestAccUser_Local_Update_DefaultLanguage(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_language": "russian"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_language": "russian"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_language", ""),
           testAccCheckUserExists("mssql_user.update", Check{"default_language", "==", ""}),
@@ -214,7 +309,7 @@ func TestAccUser_Local_Update_Roles(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "0"),
           testAccCheckUserExists("mssql_user.update", Check{"roles", "==", []string{}}),
@@ -222,7 +317,7 @@ func TestAccUser_Local_Update_Roles(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\",\"db_datawriter\"]"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\",\"db_datawriter\"]"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "2"),
           resource.TestCheckResourceAttr("mssql_user.update", "roles.0", "db_owner"),
@@ -232,7 +327,7 @@ func TestAccUser_Local_Update_Roles(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", false, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "update", "login", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "1"),
           resource.TestCheckResourceAttr("mssql_user.update", "roles.0", "db_owner"),
@@ -251,7 +346,7 @@ func TestAccUser_Azure_Update_DefaultSchema(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_schema", "dbo"),
           testAccCheckUserExists("mssql_user.update", Check{"default_schema", "==", "dbo"}),
@@ -259,7 +354,7 @@ func TestAccUser_Azure_Update_DefaultSchema(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_schema": "sys"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_schema": "sys"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_schema", "sys"),
           testAccCheckUserExists("mssql_user.update", Check{"default_schema", "==", "sys"}),
@@ -277,7 +372,7 @@ func TestAccUser_Azure_Update_DefaultLanguage(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_language", ""),
           testAccCheckUserExists("mssql_user.update", Check{"default_language", "==", ""}),
@@ -285,7 +380,7 @@ func TestAccUser_Azure_Update_DefaultLanguage(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_language": "russian"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "default_language": "russian"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "default_language", ""),
           testAccCheckUserExists("mssql_user.update", Check{"default_language", "==", ""}),
@@ -303,7 +398,7 @@ func TestAccUser_Azure_Update_Roles(t *testing.T) {
     CheckDestroy:      func(state *terraform.State) error { return testAccCheckLoginDestroy(state) },
     Steps: []resource.TestStep{
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "0"),
           testAccCheckUserExists("mssql_user.update", Check{"roles", "==", []string{}}),
@@ -311,7 +406,7 @@ func TestAccUser_Azure_Update_Roles(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\",\"db_datawriter\"]"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\",\"db_datawriter\"]"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "2"),
           resource.TestCheckResourceAttr("mssql_user.update", "roles.0", "db_owner"),
@@ -321,7 +416,7 @@ func TestAccUser_Azure_Update_Roles(t *testing.T) {
         ),
       },
       {
-        Config: testAccCheckUser(t, "update", true, map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
+        Config: testAccCheckUser(t, "update", "azure", map[string]interface{}{"database": "testdb", "username": "test_update", "login_name": "user_update", "login_password": "valueIsH8kd$¡", "roles": "[\"db_owner\"]"}),
         Check: resource.ComposeTestCheckFunc(
           resource.TestCheckResourceAttr("mssql_user.update", "roles.#", "1"),
           resource.TestCheckResourceAttr("mssql_user.update", "roles.0", "db_owner"),
@@ -333,12 +428,12 @@ func TestAccUser_Azure_Update_Roles(t *testing.T) {
   })
 }
 
-func testAccCheckUser(t *testing.T, name string, azure bool, data map[string]interface{}) string {
+func testAccCheckUser(t *testing.T, name string, login string, data map[string]interface{}) string {
   text := `{{ if .login_name }}
            resource "mssql_login" "{{ .name }}" {
              server {
                host = "{{ .host }}"
-               {{ if .azure }}azure_login {}{{ else }}login {}{{ end }}
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
              }
              login_name = "{{ .login_name }}"
              password   = "{{ .login_password }}"
@@ -347,7 +442,7 @@ func testAccCheckUser(t *testing.T, name string, azure bool, data map[string]int
            resource "mssql_user" "{{ .name }}" {
              server {
                host = "{{ .host }}"
-               {{ if .azure }}azure_login {}{{ else }}login {}{{ end }}
+               {{if eq .login "fedauth"}}azuread_default_chain_auth {}{{ else if eq .login "msi"}}azuread_managed_identity_auth {}{{ else if eq .login "azure" }}azure_login {}{{ else }}login {}{{ end }}
              }
              {{ with .database }}database = "{{ . }}"{{ end }}
              username = "{{ .username }}"
@@ -358,11 +453,13 @@ func testAccCheckUser(t *testing.T, name string, azure bool, data map[string]int
              {{ with .roles }}roles = {{ . }}{{ end }}
            }`
   data["name"] = name
-  data["azure"] = azure
-  if azure {
+  data["login"] = login
+  if login == "fedauth" || login == "msi" || login == "azure" {
     data["host"] = os.Getenv("TF_ACC_SQL_SERVER")
-  } else {
+  } else if login == "login" {
     data["host"] = "localhost"
+  } else {
+    t.Fatalf("login expected to be one of 'login', 'azure', 'msi', 'fedauth', got %s", login)
   }
   res, err := templateToString(name, text, data)
   if err != nil {

--- a/mssql/server.go
+++ b/mssql/server.go
@@ -16,6 +16,12 @@ func getServerSchema(prefix string) map[string]*schema.Schema {
 	if len(prefix) > 0 {
 		prefix = prefix + ".0."
 	}
+	var LoginMethods = []string{
+		prefix + "login",
+		prefix + "azure_login",
+		prefix + "azuread_default_chain_auth",
+		prefix + "azuread_managed_identity_auth",
+	}
 	return map[string]*schema.Schema{
 		"host": {
 			Type:     schema.TypeString,
@@ -35,7 +41,7 @@ func getServerSchema(prefix string) map[string]*schema.Schema {
 			Type:         schema.TypeList,
 			MaxItems:     1,
 			Optional:     true,
-			ExactlyOneOf: []string{prefix + "login", prefix + "azure_login"},
+			ExactlyOneOf: LoginMethods,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"username": {
@@ -56,7 +62,7 @@ func getServerSchema(prefix string) map[string]*schema.Schema {
 			Type:         schema.TypeList,
 			MaxItems:     1,
 			Optional:     true,
-			ExactlyOneOf: []string{prefix + "login", prefix + "azure_login"},
+			ExactlyOneOf: LoginMethods,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"tenant_id": {
@@ -74,6 +80,27 @@ func getServerSchema(prefix string) map[string]*schema.Schema {
 						Required:    true,
 						Sensitive:   true,
 						DefaultFunc: schema.EnvDefaultFunc("MSSQL_CLIENT_SECRET", nil),
+					},
+				},
+			},
+		},
+		"azuread_default_chain_auth": {
+			Type:         schema.TypeList,
+			MaxItems:     1,
+			Optional:     true,
+			ExactlyOneOf: LoginMethods,
+			Elem:         &schema.Resource{},
+		},
+		"azuread_managed_identity_auth": {
+			Type:         schema.TypeList,
+			MaxItems:     1,
+			Optional:     true,
+			ExactlyOneOf: LoginMethods,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"user_id": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 				},
 			},

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -8,6 +8,7 @@ import (
   "github.com/Azure/go-autorest/autorest/adal"
   "github.com/Azure/go-autorest/autorest/azure"
   mssql "github.com/denisenkom/go-mssqldb"
+  "github.com/denisenkom/go-mssqldb/azuread"
   "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
   "github.com/pkg/errors"
   "log"
@@ -51,6 +52,13 @@ func (f factory) GetConnector(prefix string, data *schema.ResourceData) (interfa
     }
   }
 
+  if admin, ok := data.GetOk(prefix + "azuread_managed_identity_auth.0"); ok {
+    admin := admin.(map[string]interface{})
+    connector.FedauthMSI = &FedauthMSI{
+      UserID: admin["user_id"].(string),
+    }
+  }
+
   return connector, nil
 }
 
@@ -60,6 +68,7 @@ type Connector struct {
   Database   string `json:"database"`
   Login      *LoginUser
   AzureLogin *AzureLogin
+  FedauthMSI *FedauthMSI
   Timeout    time.Duration `json:"timeout,omitempty"`
   Token      string
 }
@@ -73,6 +82,10 @@ type AzureLogin struct {
   TenantID     string `json:"tenant_id,omitempty"`
   ClientID     string `json:"client_id,omitempty"`
   ClientSecret string `json:"client_secret,omitempty"`
+}
+
+type FedauthMSI struct {
+  UserID string `json:"user_id,omitempty"`
 }
 
 func (c *Connector) PingContext(ctx context.Context) error {
@@ -158,19 +171,36 @@ func (c *Connector) db() (*sql.DB, error) {
 
 func (c *Connector) connector() (driver.Connector, error) {
   query := url.Values{}
+  host := fmt.Sprintf("%s:%s", c.Host, c.Port)
   if c.Database != "" {
     query.Set("database", c.Database)
   }
+  if c.Login != nil || c.AzureLogin != nil {
+    connectionString := (&url.URL{
+      Scheme:   "sqlserver",
+      User:     c.userPassword(),
+      Host:     host,
+      RawQuery: query.Encode(),
+    }).String()
+    if c.Login != nil {
+        return mssql.NewConnector(connectionString)
+    }
+    return mssql.NewAccessTokenConnector(connectionString, func() (string, error) { return c.tokenProvider() })
+  }
+  if c.FedauthMSI != nil {
+    query.Set("fedauth", "ActiveDirectoryManagedIdentity")
+    if c.FedauthMSI.UserID != "" {
+      query.Set("user id", c.FedauthMSI.UserID)
+    }
+  } else {
+    query.Set("fedauth", "ActiveDirectoryDefault")
+  }
   connectionString := (&url.URL{
     Scheme:   "sqlserver",
-    User:     c.userPassword(),
-    Host:     fmt.Sprintf("%s:%s", c.Host, c.Port),
+    Host:     host,
     RawQuery: query.Encode(),
   }).String()
-  if c.Login != nil {
-    return mssql.NewConnector(connectionString)
-  }
-  return mssql.NewAccessTokenConnector(connectionString, func() (string, error) { return c.tokenProvider() })
+  return azuread.NewConnector(connectionString)
 }
 
 func (c *Connector) userPassword() *url.Userinfo {

--- a/test-fixtures/all/main.tf
+++ b/test-fixtures/all/main.tf
@@ -142,5 +142,9 @@ resource "local_sensitive_file" "local_env" {
                          export TF_ACC_AZURE_USER_CLIENT_ID='${azuread_service_principal.user.application_id}'
                          export TF_ACC_AZURE_USER_CLIENT_USER='${azuread_service_principal.user.display_name}'
                          export TF_ACC_AZURE_USER_CLIENT_SECRET='${azuread_service_principal_password.user.value}'
+                         # Configuration for fedauth which uses env vars via DefaultAzureCredential
+                         export AZURE_TENANT_ID='${var.tenant_id}'
+                         export AZURE_CLIENT_ID='${azuread_service_principal.sa.application_id}'
+                         export AZURE_CLIENT_SECRET='${azuread_service_principal_password.sa.value}'
                          EOT
 }


### PR DESCRIPTION
Fixes #30.

This PR implements two of the auth forms available through the new [fedauth](https://github.com/denisenkom/go-mssqldb#azure-active-directory-authentication): `ActiveDirectoryDefault` and `ActiveDirectoryManagedIdentity` (because user-assigned identity) as these are the most useful variants.