### PR TITLE
STRING_AGG doesn't exist on SQL Server 2016

### DIFF
--- a/sql/user.go
+++ b/sql/user.go
@@ -33,7 +33,7 @@ func (c *Connector) GetUser(ctx context.Context, database, username string) (*mo
                           '  SELECT member_principal_id, drm.role_principal_id FROM ' + QuoteName(@database) + '.[sys].[database_role_members] drm' +
                           '    INNER JOIN CTE_Roles cr ON drm.member_principal_id = cr.role_principal_id' +
                           ') ' +
-                          'SELECT p.principal_id, p.name, p.authentication_type_desc, COALESCE(p.default_schema_name, ''''), COALESCE(p.default_language_name, ''''), p.sid, CONVERT(VARCHAR(1000), p.sid, 1) AS sidStr, COALESCE(sl.name, ''''), COALESCE(STUFF((SELECT '' + USER_NAME(r.role_principal_id) FROM CTE_Roles r WHERE r.principal_id = p.principal_id FOR XML PATH ('')), 1, 0, ''), '''') ' +
+                          'SELECT p.principal_id, p.name, p.authentication_type_desc, COALESCE(p.default_schema_name, ''''), COALESCE(p.default_language_name, ''''), p.sid, CONVERT(VARCHAR(1000), p.sid, 1) AS sidStr, COALESCE(sl.name, ''''), COALESCE(STUFF((SELECT '','' + USER_NAME(r.role_principal_id) FROM CTE_Roles r WHERE r.principal_id = p.principal_id FOR XML PATH ('''')), 0, 0, ''''), '''') ' +
                           'FROM ' + QuoteName(@database) + '.[sys].[database_principals] p' +
                           '  LEFT JOIN [master].[sys].[sql_logins] sl ON p.sid = sl.sid ' +
                           'WHERE p.name = ' + QuoteName(@username, '''') + ' ' +

--- a/sql/user.go
+++ b/sql/user.go
@@ -33,7 +33,7 @@ func (c *Connector) GetUser(ctx context.Context, database, username string) (*mo
                           '  SELECT member_principal_id, drm.role_principal_id FROM ' + QuoteName(@database) + '.[sys].[database_role_members] drm' +
                           '    INNER JOIN CTE_Roles cr ON drm.member_principal_id = cr.role_principal_id' +
                           ') ' +
-                          'SELECT p.principal_id, p.name, p.authentication_type_desc, COALESCE(p.default_schema_name, ''''), COALESCE(p.default_language_name, ''''), p.sid, CONVERT(VARCHAR(1000), p.sid, 1) AS sidStr, COALESCE(sl.name, ''''), COALESCE(STRING_AGG(USER_NAME(r.role_principal_id), '',''), '''') ' +
+                          'SELECT p.principal_id, p.name, p.authentication_type_desc, COALESCE(p.default_schema_name, ''''), COALESCE(p.default_language_name, ''''), p.sid, CONVERT(VARCHAR(1000), p.sid, 1) AS sidStr, COALESCE(sl.name, ''''), COALESCE(STUFF((SELECT '' + USER_NAME(r.role_principal_id) FROM CTE_Roles r WHERE r.principal_id = p.principal_id FOR XML PATH ('')), 1, 0, ''), '''') ' +
                           'FROM ' + QuoteName(@database) + '.[sys].[database_principals] p' +
                           '  LEFT JOIN CTE_Roles r ON p.principal_id = r.principal_id ' +
                           '  LEFT JOIN [master].[sys].[sql_logins] sl ON p.sid = sl.sid ' +

--- a/sql/user.go
+++ b/sql/user.go
@@ -35,7 +35,6 @@ func (c *Connector) GetUser(ctx context.Context, database, username string) (*mo
                           ') ' +
                           'SELECT p.principal_id, p.name, p.authentication_type_desc, COALESCE(p.default_schema_name, ''''), COALESCE(p.default_language_name, ''''), p.sid, CONVERT(VARCHAR(1000), p.sid, 1) AS sidStr, COALESCE(sl.name, ''''), COALESCE(STUFF((SELECT '' + USER_NAME(r.role_principal_id) FROM CTE_Roles r WHERE r.principal_id = p.principal_id FOR XML PATH ('')), 1, 0, ''), '''') ' +
                           'FROM ' + QuoteName(@database) + '.[sys].[database_principals] p' +
-                          '  LEFT JOIN CTE_Roles r ON p.principal_id = r.principal_id ' +
                           '  LEFT JOIN [master].[sys].[sql_logins] sl ON p.sid = sl.sid ' +
                           'WHERE p.name = ' + QuoteName(@username, '''') + ' ' +
                           'GROUP BY p.principal_id, p.name, p.authentication_type_desc, p.default_schema_name, p.default_language_name, p.sid, sl.name'


### PR DESCRIPTION
Fix for the following error when creating a user on SQL server 2016 (13.0.6419.1):


```
mssql_login.vm_sql_login: Creation complete after 8s [id={redacted}]
╷
│ Error: unable to read user {redacted}: mssql: 'STRING_AGG' is not a recognized built-in function name.
```