### PR TITLE
Support read timeout for SQL loop and better error handling

### DIFF
--- a/mssql/resource_login.go
+++ b/mssql/resource_login.go
@@ -71,6 +71,7 @@ func resourceLogin() *schema.Resource {
     },
     Timeouts: &schema.ResourceTimeout{
       Default: defaultTimeout,
+      Read: defaultTimeout,
     },
   }
 }

--- a/mssql/resource_user.go
+++ b/mssql/resource_user.go
@@ -89,6 +89,7 @@ func resourceUser() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Default: defaultTimeout,
+			Read: defaultTimeout,
 		},
 	}
 }

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -249,13 +249,22 @@ func connectLoop(connector driver.Connector, timeout time.Duration) (*sql.DB, er
       if err == nil {
         return db, nil
       }
-      if strings.Contains(err.Error(), "Login failed") {
+      if strings.Contains(strings.ToLower(err.Error()), "login failed") {
         return nil, err
       }
-      if strings.Contains(err.Error(), "Login error") {
+      if strings.Contains(strings.ToLower(err.Error()), "login error") {
         return nil, err
       }
       if strings.Contains(err.Error(), "error retrieving access token") {
+        return nil, err
+      }
+      if strings.Contains(err.Error(), "AuthenticationFailedError") {
+        return nil, err
+      }
+      if strings.Contains(err.Error(), "credential") {
+        return nil, err
+      }
+      if strings.Contains(err.Error(), "request failed") {
         return nil, err
       }
       log.Println(errors.Wrap(err, "failed to connect to database"))


### PR DESCRIPTION
Implement read timeout parameter as it is used in [SQL Connector](https://github.com/betr-io/terraform-provider-mssql/blob/master/sql/sql.go#L35) for the [loop timeout](https://github.com/betr-io/terraform-provider-mssql/blob/master/sql/sql.go#L165). Related to #16

Also handle  a couple of error I encountered while debugging, so that the loop exits early and print the error to the user (without having to run with `TF_LOG=info`. Should be helpful for #12 #25 #57

Dumping the logs i had on info level that made me add the extra lines : 

```
failed to connect to database: Received an AuthenticationFailedError, there is an invalid credential in the chain.  details: invalid_request AADSTS90002: Tenant '456' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.

failed to connect to database: mssql: login error: Cannot open server '' requested by the login. Client with IP address '' is not allowed to access the server.  [...]

failed to connect to database: Chained Token Credential: Azure CLI Credential: exec: "az": executable file not found in $PATH: timestamp=2023-06-19T22:10:20.069Z

Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"[...]","error_codes":[90002],"error_uri":"https://login.microsoftonline.com/error?code=90002"} 

```

### Tests 

* Compiled with `make build`

* [Installed locally ](https://stackoverflow.com/questions/68182628/terraform-use-local-provider-plugin) using the following test file 
 
```hcl
terraform {
  backend "local" {}
  required_providers {
    mssql = {
      source  = "terraform.local/local/mssql"
      version = ">=0.2.7"
    }
  }
}

provider "mssql"{
      debug = true
}



resource "mssql_user" "example" {
  server {
    host = "example.database.windows.net"
    azuread_default_chain_auth {}

  }
  username  = "username"
  database  = "database"
  roles     = ["db_datareader"]

  timeouts {
     read = "5s"
   }
}

```

Run with 
```bash
rm .terraform.lock.hcl &&  terraform init && TF_LOG=info terraform apply -auto-approve
```

@magne let me know if that make sense to you