### PR TITLE
Introduce DB connection pooling to prevent saturating session/connection limits

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,11 @@ terraform {
 }
 
 provider "mssql" {
-  debug = "false"
+  debug                   = false
+  max_open_connections    = 10
+  max_idle_connections    = 10
+  connection_max_lifetime = 300
+  connection_max_idle_time = 120
 }
 
 resource "mssql_login" "example" {
@@ -48,3 +52,7 @@ resource "mssql_user" "example" {
 The following arguments are supported:
 
 * `debug` - (Optional) Either `false` or `true`. Defaults to `false`. If `true`, the provider will write a debug log to `terraform-provider-mssql.log`.
+* `max_open_connections` - (Optional) Maximum number of open connections to the database. Limits concurrent sessions to prevent exhausting server session limits. Defaults to `10`.
+* `max_idle_connections` - (Optional) Maximum number of idle connections kept in the pool, ready for reuse. Avoids the latency of establishing new connections under load. Defaults to `10`.
+* `connection_max_lifetime` - (Optional) Maximum lifetime of a connection in seconds. Expired connections are closed gracefully after use. Set to `0` for unlimited. Defaults to `300`.
+* `connection_max_idle_time` - (Optional) Maximum time in seconds a connection may be idle before being closed. Helps free resources from unused connections. Set to `0` to disable. Defaults to `120`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,11 @@ terraform {
 }
 
 provider "mssql" {
-  debug                   = false
-  max_open_connections    = 10
-  max_idle_connections    = 10
-  connection_max_lifetime = 300
-  connection_max_idle_time = 120
+  debug                    = false
+  max_open_connections     = 0
+  max_idle_connections     = 2
+  connection_max_lifetime  = 0
+  connection_max_idle_time = 0
 }
 
 resource "mssql_login" "example" {
@@ -52,7 +52,7 @@ resource "mssql_user" "example" {
 The following arguments are supported:
 
 * `debug` - (Optional) Either `false` or `true`. Defaults to `false`. If `true`, the provider will write a debug log to `terraform-provider-mssql.log`.
-* `max_open_connections` - (Optional) Maximum number of open connections to the database. Limits concurrent sessions to prevent exhausting server session limits. Defaults to `10`.
-* `max_idle_connections` - (Optional) Maximum number of idle connections kept in the pool, ready for reuse. Avoids the latency of establishing new connections under load. Defaults to `10`.
-* `connection_max_lifetime` - (Optional) Maximum lifetime of a connection in seconds. Expired connections are closed gracefully after use. Set to `0` for unlimited. Defaults to `300`.
-* `connection_max_idle_time` - (Optional) Maximum time in seconds a connection may be idle before being closed. Helps free resources from unused connections. Set to `0` to disable. Defaults to `120`.
+* `max_open_connections` - (Optional) Maximum number of open connections to the database. If set to 0, there is no limit on the number of open connections. Defaults to `0`.
+* `max_idle_connections` - (Optional) Maximum number of idle connections in the pool. If set to 0, no idle connections are retained. Defaults to `2`.
+* `connection_max_lifetime` - (Optional) Maximum lifetime of a connection in seconds. If set to 0, connections are not closed due to a connection's age. Defaults to `0`.
+* `connection_max_idle_time` - (Optional) Maximum time in seconds a connection may be idle before being closed. If set to 0, connections are not closed due to a connection's idle time. Defaults to `0`.

--- a/mssql/provider.go
+++ b/mssql/provider.go
@@ -1,91 +1,137 @@
 package mssql
 
 import (
-  "context"
-  "fmt"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-  "github.com/rs/zerolog"
-  "github.com/rs/zerolog/log"
-  "io"
-  "os"
-  "github.com/betr-io/terraform-provider-mssql/mssql/model"
-  "github.com/betr-io/terraform-provider-mssql/sql"
-  "time"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/betr-io/terraform-provider-mssql/mssql/model"
+	"github.com/betr-io/terraform-provider-mssql/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type mssqlProvider struct {
-  factory model.ConnectorFactory
-  logger  *zerolog.Logger
+	factory model.ConnectorFactory
+	logger  *zerolog.Logger
 }
 
 const (
-  providerLogFile = "terraform-provider-mssql.log"
+	providerLogFile = "terraform-provider-mssql.log"
 )
 
 var (
-  defaultTimeout = schema.DefaultTimeout(30 * time.Second)
+	defaultTimeout = schema.DefaultTimeout(30 * time.Second)
 )
 
 func New(version, commit string) func() *schema.Provider {
-  return func() *schema.Provider {
-    return Provider(sql.GetFactory())
-  }
+	return func() *schema.Provider {
+		return Provider(sql.GetFactory())
+	}
 }
 
 func Provider(factory model.ConnectorFactory) *schema.Provider {
-  return &schema.Provider{
-    Schema: map[string]*schema.Schema{
-      "debug": {
-        Type:        schema.TypeBool,
-        Description: fmt.Sprintf("Enable provider debug logging (logs to file %s)", providerLogFile),
-        Optional:    true,
-        Default:     false,
-      },
-    },
-    ResourcesMap: map[string]*schema.Resource{
-      "mssql_login": resourceLogin(),
-      "mssql_user":  resourceUser(),
-    },
-    DataSourcesMap: map[string]*schema.Resource{},
-    ConfigureContextFunc: func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
-      return providerConfigure(ctx, data, factory)
-    },
-  }
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"debug": {
+				Type:        schema.TypeBool,
+				Description: fmt.Sprintf("Enable provider debug logging (logs to file %s)", providerLogFile),
+				Optional:    true,
+				Default:     false,
+			},
+			"max_open_connections": {
+				Type:        schema.TypeInt,
+				Description: "Maximum number of open connections to the database. Limits concurrent sessions to prevent exhausting server session limits.",
+				Optional:    true,
+				Default:     10,
+			},
+			"max_idle_connections": {
+				Type:        schema.TypeInt,
+				Description: "Maximum number of idle connections kept in the pool, ready for reuse. Avoids the latency of establishing new connections under load.",
+				Optional:    true,
+				Default:     10,
+			},
+			"connection_max_lifetime": {
+				Type:        schema.TypeInt,
+				Description: "Maximum lifetime of a connection in seconds. Expired connections are closed gracefully after use. Set to 0 for unlimited.",
+				Optional:    true,
+				Default:     300,
+			},
+			"connection_max_idle_time": {
+				Type:        schema.TypeInt,
+				Description: "Maximum time in seconds a connection may be idle before being closed. Helps free resources from unused connections. Set to 0 to disable.",
+				Optional:    true,
+				Default:     120,
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"mssql_login": resourceLogin(),
+			"mssql_user":  resourceUser(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{},
+		ConfigureContextFunc: func(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+			return providerConfigure(ctx, data, factory)
+		},
+	}
 }
 
 func providerConfigure(ctx context.Context, data *schema.ResourceData, factory model.ConnectorFactory) (model.Provider, diag.Diagnostics) {
-  isDebug := data.Get("debug").(bool)
-  logger := newLogger(isDebug)
+	isDebug := data.Get("debug").(bool)
+	logger := newLogger(isDebug)
 
-  logger.Info().Msg("Created provider")
+	// Read pool configuration from provider block
+	maxOpenConns := data.Get("max_open_connections").(int)
+	maxIdleConns := data.Get("max_idle_connections").(int)
+	connMaxLifetime := data.Get("connection_max_lifetime").(int)
+	connMaxIdleTime := data.Get("connection_max_idle_time").(int)
 
-  return mssqlProvider{factory: factory, logger: logger}, nil
+	poolConfig := sql.PoolConfig{
+		MaxOpenConnections:    maxOpenConns,
+		MaxIdleConnections:    maxIdleConns,
+		ConnectionMaxLifetime: time.Duration(connMaxLifetime) * time.Second,
+		ConnectionMaxIdleTime: time.Duration(connMaxIdleTime) * time.Second,
+	}
+
+	// Apply pool configuration to the existing factory
+	sql.ConfigureFactory(factory, poolConfig)
+
+	logger.Info().
+		Int("max_open_connections", maxOpenConns).
+		Int("max_idle_connections", maxIdleConns).
+		Int("connection_max_lifetime_seconds", connMaxLifetime).
+		Int("connection_max_idle_time_seconds", connMaxIdleTime).
+		Msg("Created provider")
+
+	return mssqlProvider{factory: factory, logger: logger}, nil
 }
 
 func (p mssqlProvider) GetConnector(prefix string, data *schema.ResourceData) (interface{}, error) {
-  return p.factory.GetConnector(prefix, data)
+	return p.factory.GetConnector(prefix, data)
 }
 
 func (p mssqlProvider) ResourceLogger(resource, function string) zerolog.Logger {
-  return p.logger.With().Str("resource", resource).Str("func", function).Logger()
+	return p.logger.With().Str("resource", resource).Str("func", function).Logger()
 }
 
 func (p mssqlProvider) DataSourceLogger(datasource, function string) zerolog.Logger {
-  return p.logger.With().Str("datasource", datasource).Str("func", function).Logger()
+	return p.logger.With().Str("datasource", datasource).Str("func", function).Logger()
 }
 
 func newLogger(isDebug bool) *zerolog.Logger {
-  var writer io.Writer = nil
-  logLevel := zerolog.Disabled
-  if isDebug {
-    f, err := os.OpenFile(providerLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-    if err != nil {
-      log.Err(err).Msg("error opening file")
-    }
-    writer = f
-    logLevel = zerolog.DebugLevel
-  }
-  logger := zerolog.New(writer).Level(logLevel).With().Timestamp().Logger()
-  return &logger
+	var writer io.Writer = nil
+	logLevel := zerolog.Disabled
+	if isDebug {
+		f, err := os.OpenFile(providerLogFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			log.Err(err).Msg("error opening file")
+		}
+		writer = f
+		logLevel = zerolog.DebugLevel
+	}
+	logger := zerolog.New(writer).Level(logLevel).With().Timestamp().Logger()
+	return &logger
 }

--- a/mssql/provider.go
+++ b/mssql/provider.go
@@ -45,27 +45,27 @@ func Provider(factory model.ConnectorFactory) *schema.Provider {
 			},
 			"max_open_connections": {
 				Type:        schema.TypeInt,
-				Description: "Maximum number of open connections to the database. Limits concurrent sessions to prevent exhausting server session limits.",
+				Description: "Maximum number of open connections to the database. Limits concurrent sessions to prevent exhausting server session limits. Set to 0 for unlimited.",
 				Optional:    true,
-				Default:     10,
+				Default:     0,
 			},
 			"max_idle_connections": {
 				Type:        schema.TypeInt,
 				Description: "Maximum number of idle connections kept in the pool, ready for reuse. Avoids the latency of establishing new connections under load.",
 				Optional:    true,
-				Default:     10,
+				Default:     2,
 			},
 			"connection_max_lifetime": {
 				Type:        schema.TypeInt,
 				Description: "Maximum lifetime of a connection in seconds. Expired connections are closed gracefully after use. Set to 0 for unlimited.",
 				Optional:    true,
-				Default:     300,
+				Default:     0,
 			},
 			"connection_max_idle_time": {
 				Type:        schema.TypeInt,
 				Description: "Maximum time in seconds a connection may be idle before being closed. Helps free resources from unused connections. Set to 0 to disable.",
 				Optional:    true,
-				Default:     120,
+				Default:     0,
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/mssql/provider_test.go
+++ b/mssql/provider_test.go
@@ -1,19 +1,20 @@
 package mssql
 
 import (
-  "bytes"
-  "context"
-  sql2 "database/sql"
-  "fmt"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-  "os"
-  "strconv"
-  "github.com/betr-io/terraform-provider-mssql/mssql/model"
-  "github.com/betr-io/terraform-provider-mssql/sql"
-  "testing"
-  "text/template"
-  "time"
+	"bytes"
+	"context"
+	sql2 "database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/betr-io/terraform-provider-mssql/mssql/model"
+	"github.com/betr-io/terraform-provider-mssql/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 var runLocalAccTests bool
@@ -21,184 +22,231 @@ var testAccProvider *schema.Provider
 var testAccProviders map[string]func() (*schema.Provider, error)
 
 func init() {
-  _, runLocalAccTests = os.LookupEnv("TF_ACC_LOCAL")
-  testAccProvider = Provider(sql.GetFactory())
-  testAccProviders = map[string]func() (*schema.Provider, error){
-    "mssql": func() (*schema.Provider, error) {
-      return testAccProvider, nil
-    },
-  }
+	_, runLocalAccTests = os.LookupEnv("TF_ACC_LOCAL")
+	testAccProvider = Provider(sql.GetFactory())
+	testAccProviders = map[string]func() (*schema.Provider, error){
+		"mssql": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
+	}
 }
 
 func TestProvider(t *testing.T) {
-  if err := testAccProvider.InternalValidate(); err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	if err := testAccProvider.InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func testAccPreCheck(t *testing.T) {
-  var keys []string
-  _, azure := os.LookupEnv("TF_ACC")
-  _, local := os.LookupEnv("TF_ACC_LOCAL")
-  if local || azure {
-    keys = append(keys, "MSSQL_USERNAME", "MSSQL_PASSWORD")
-  }
-  if azure {
-    keys = append(keys, "MSSQL_TENANT_ID", "MSSQL_CLIENT_ID", "MSSQL_CLIENT_SECRET", "TF_ACC_SQL_SERVER", "TF_ACC_AZURE_USER_CLIENT_ID", "TF_ACC_AZURE_USER_CLIENT_SECRET")
-  }
-  for _, key := range keys {
-    if v := os.Getenv(key); v == "" {
-      t.Fatalf("Environment variable %s must be set for acceptance tests", key)
-    }
-  }
+	var keys []string
+	_, azure := os.LookupEnv("TF_ACC")
+	_, local := os.LookupEnv("TF_ACC_LOCAL")
+	if local || azure {
+		keys = append(keys, "MSSQL_USERNAME", "MSSQL_PASSWORD")
+	}
+	if azure {
+		keys = append(keys, "MSSQL_TENANT_ID", "MSSQL_CLIENT_ID", "MSSQL_CLIENT_SECRET", "TF_ACC_SQL_SERVER", "TF_ACC_AZURE_USER_CLIENT_ID", "TF_ACC_AZURE_USER_CLIENT_SECRET")
+	}
+	for _, key := range keys {
+		if v := os.Getenv(key); v == "" {
+			t.Fatalf("Environment variable %s must be set for acceptance tests", key)
+		}
+	}
 }
 
 type Check struct {
-  name, op string
-  expected interface{}
+	name, op string
+	expected interface{}
 }
 
 type TestConnector interface {
-  GetLogin(name string) (*model.Login, error)
-  GetUser(database, name string) (*model.User, error)
-  GetSystemUser() (string, error)
-  GetCurrentUser(database string) (string, string, error)
+	GetLogin(name string) (*model.Login, error)
+	GetUser(database, name string) (*model.User, error)
+	GetSystemUser() (string, error)
+	GetCurrentUser(database string) (string, string, error)
 }
 
 type testConnector struct {
-  c interface{}
+	c interface{}
 }
 
 func getTestConnector(a map[string]string) (TestConnector, error) {
-  prefix := serverProp + ".0."
+	prefix := serverProp + ".0."
 
-  connector := &sql.Connector{
-    Host:    a[prefix+"host"],
-    Port:    a[prefix+"port"],
-    Timeout: 60 * time.Second,
-  }
+	connector := &sql.Connector{
+		Host:    a[prefix+"host"],
+		Port:    a[prefix+"port"],
+		Timeout: 60 * time.Second,
+	}
 
-  if username, ok := a[prefix+"login.0.username"]; ok {
-    connector.Login = &sql.LoginUser{
-      Username: username,
-      Password: a[prefix+"login.0.password"],
-    }
-  }
+	if username, ok := a[prefix+"login.0.username"]; ok {
+		connector.Login = &sql.LoginUser{
+			Username: username,
+			Password: a[prefix+"login.0.password"],
+		}
+	}
 
-  if tenantId, ok := a[prefix+"azure_login.0.tenant_id"]; ok {
-    connector.AzureLogin = &sql.AzureLogin{
-      TenantID:     tenantId,
-      ClientID:     a[prefix+"azure_login.0.client_id"],
-      ClientSecret: a[prefix+"azure_login.0.client_secret"],
-    }
-  }
+	if tenantId, ok := a[prefix+"azure_login.0.tenant_id"]; ok {
+		connector.AzureLogin = &sql.AzureLogin{
+			TenantID:     tenantId,
+			ClientID:     a[prefix+"azure_login.0.client_id"],
+			ClientSecret: a[prefix+"azure_login.0.client_secret"],
+		}
+	}
 
-  return testConnector{c: connector}, nil
+	return testConnector{c: connector}, nil
 }
 
 func getTestLoginConnector(a map[string]string) (TestConnector, error) {
-  prefix := serverProp + ".0."
-  connector := &sql.Connector{
-    Host:    a[prefix+"host"],
-    Port:    a[prefix+"port"],
-    Timeout: 60 * time.Second,
-  }
-  if password, ok := a[passwordProp]; ok {
-    connector.Login = &sql.LoginUser{
-      Username: a[loginNameProp],
-      Password: password,
-    }
-  }
+	prefix := serverProp + ".0."
+	connector := &sql.Connector{
+		Host:    a[prefix+"host"],
+		Port:    a[prefix+"port"],
+		Timeout: 60 * time.Second,
+	}
+	if password, ok := a[passwordProp]; ok {
+		connector.Login = &sql.LoginUser{
+			Username: a[loginNameProp],
+			Password: password,
+		}
+	}
 
-  return testConnector{c: connector}, nil
+	return testConnector{c: connector}, nil
 }
 
 func getTestUserConnector(a map[string]string, username, password string) (TestConnector, error) {
-  prefix := serverProp + ".0."
-  connector := &sql.Connector{
-    Host:    a[prefix+"host"],
-    Port:    a[prefix+"port"],
-    Timeout: 60 * time.Second,
-  }
-  connector.Login = &sql.LoginUser{
-    Username: username,
-    Password: password,
-  }
-  if database, ok := a[databaseProp]; ok {
-    connector.Database = database
-  }
+	prefix := serverProp + ".0."
+	connector := &sql.Connector{
+		Host:    a[prefix+"host"],
+		Port:    a[prefix+"port"],
+		Timeout: 60 * time.Second,
+	}
+	connector.Login = &sql.LoginUser{
+		Username: username,
+		Password: password,
+	}
+	if database, ok := a[databaseProp]; ok {
+		connector.Database = database
+	}
 
-  return testConnector{c: connector}, nil
+	return testConnector{c: connector}, nil
 }
 
 func getTestExternalConnector(a map[string]string, tenantId, clientId, clientSecret string) (TestConnector, error) {
-  prefix := serverProp + ".0."
-  connector := &sql.Connector{
-    Host:    a[prefix+"host"],
-    Port:    a[prefix+"port"],
-    Timeout: 60 * time.Second,
-  }
-  connector.AzureLogin = &sql.AzureLogin{
-    TenantID:     tenantId,
-    ClientID:     clientId,
-    ClientSecret: clientSecret,
-  }
-  if database, ok := a[databaseProp]; ok {
-    connector.Database = database
-  }
+	prefix := serverProp + ".0."
+	connector := &sql.Connector{
+		Host:    a[prefix+"host"],
+		Port:    a[prefix+"port"],
+		Timeout: 60 * time.Second,
+	}
+	connector.AzureLogin = &sql.AzureLogin{
+		TenantID:     tenantId,
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+	}
+	if database, ok := a[databaseProp]; ok {
+		connector.Database = database
+	}
 
-  return testConnector{c: connector}, nil
+	return testConnector{c: connector}, nil
 }
 
 func (t testConnector) GetLogin(name string) (*model.Login, error) {
-  return t.c.(LoginConnector).GetLogin(context.Background(), name)
+	return t.c.(LoginConnector).GetLogin(context.Background(), name)
 }
 
 func (t testConnector) GetUser(database, name string) (*model.User, error) {
-  return t.c.(UserConnector).GetUser(context.Background(), database, name)
+	return t.c.(UserConnector).GetUser(context.Background(), database, name)
 }
 
 func (t testConnector) GetSystemUser() (string, error) {
-  var user string
-  err := t.c.(*sql.Connector).QueryRowContext(context.Background(), "SELECT SYSTEM_USER;", func(row *sql2.Row) error {
-    return row.Scan(&user)
-  })
-  return user, err
+	var user string
+	err := t.c.(*sql.Connector).QueryRowContext(context.Background(), "SELECT SYSTEM_USER;", func(row *sql2.Row) error {
+		return row.Scan(&user)
+	})
+	return user, err
 }
 
 func (t testConnector) GetCurrentUser(database string) (string, string, error) {
-  if database == "" {
-    database = "master"
-  }
-  t.c.(*sql.Connector).Database = database
-  var current, system string
-  err := t.c.(*sql.Connector).QueryRowContext(context.Background(), "SELECT CURRENT_USER, SYSTEM_USER;", func(row *sql2.Row) error {
-    return row.Scan(&current, &system)
-  })
-  return current, system, err
+	if database == "" {
+		database = "master"
+	}
+	t.c.(*sql.Connector).Database = database
+	var current, system string
+	err := t.c.(*sql.Connector).QueryRowContext(context.Background(), "SELECT CURRENT_USER, SYSTEM_USER;", func(row *sql2.Row) error {
+		return row.Scan(&current, &system)
+	})
+	return current, system, err
+}
+
+func TestProvider_PoolConfigSchemaDefaults(t *testing.T) {
+	p := Provider(sql.GetFactory())
+
+	s, ok := p.Schema["max_open_connections"]
+	if !ok {
+		t.Fatal("expected max_open_connections in provider schema")
+	}
+	if s.Default != 10 {
+		t.Errorf("expected max_open_connections default=10, got %v", s.Default)
+	}
+	if !s.Optional {
+		t.Error("expected max_open_connections to be optional")
+	}
+
+	s, ok = p.Schema["max_idle_connections"]
+	if !ok {
+		t.Fatal("expected max_idle_connections in provider schema")
+	}
+	if s.Default != 10 {
+		t.Errorf("expected max_idle_connections default=10, got %v", s.Default)
+	}
+
+	s, ok = p.Schema["connection_max_lifetime"]
+	if !ok {
+		t.Fatal("expected connection_max_lifetime in provider schema")
+	}
+	if s.Default != 300 {
+		t.Errorf("expected connection_max_lifetime default=300, got %v", s.Default)
+	}
+
+	s, ok = p.Schema["connection_max_idle_time"]
+	if !ok {
+		t.Fatal("expected connection_max_idle_time in provider schema")
+	}
+	if s.Default != 120 {
+		t.Errorf("expected connection_max_idle_time default=120, got %v", s.Default)
+	}
+}
+
+func TestProvider_PoolConfigSchemaValidation(t *testing.T) {
+	p := Provider(sql.GetFactory())
+
+	if err := p.InternalValidate(); err != nil {
+		t.Fatalf("provider schema validation failed: %s", err)
+	}
 }
 
 func templateToString(name, text string, data interface{}) (string, error) {
-  t, err := template.New(name).Parse(text)
-  if err != nil {
-    return "", err
-  }
-  var doc bytes.Buffer
-  if err = t.Execute(&doc, data); err != nil {
-    return "", err
-  }
-  return doc.String(), nil
+	t, err := template.New(name).Parse(text)
+	if err != nil {
+		return "", err
+	}
+	var doc bytes.Buffer
+	if err = t.Execute(&doc, data); err != nil {
+		return "", err
+	}
+	return doc.String(), nil
 }
 
 func testAccImportStateId(resource string, azure bool) func(state *terraform.State) (string, error) {
-  return func(state *terraform.State) (string, error) {
-    rs, ok := state.RootModule().Resources[resource]
-    if !ok {
-      return "", fmt.Errorf("not found: %s", resource)
-    }
-    if rs.Primary.ID == "" {
-      return "", fmt.Errorf("no record ID is set")
-    }
-    return rs.Primary.ID + "?azure=" + strconv.FormatBool(azure), nil
-  }
+	return func(state *terraform.State) (string, error) {
+		rs, ok := state.RootModule().Resources[resource]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resource)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("no record ID is set")
+		}
+		return rs.Primary.ID + "?azure=" + strconv.FormatBool(azure), nil
+	}
 }

--- a/mssql/provider_test.go
+++ b/mssql/provider_test.go
@@ -186,8 +186,8 @@ func TestProvider_PoolConfigSchemaDefaults(t *testing.T) {
 	if !ok {
 		t.Fatal("expected max_open_connections in provider schema")
 	}
-	if s.Default != 10 {
-		t.Errorf("expected max_open_connections default=10, got %v", s.Default)
+	if s.Default != 0 {
+		t.Errorf("expected max_open_connections default=0, got %v", s.Default)
 	}
 	if !s.Optional {
 		t.Error("expected max_open_connections to be optional")
@@ -197,24 +197,24 @@ func TestProvider_PoolConfigSchemaDefaults(t *testing.T) {
 	if !ok {
 		t.Fatal("expected max_idle_connections in provider schema")
 	}
-	if s.Default != 10 {
-		t.Errorf("expected max_idle_connections default=10, got %v", s.Default)
+	if s.Default != 2 {
+		t.Errorf("expected max_idle_connections default=2, got %v", s.Default)
 	}
 
 	s, ok = p.Schema["connection_max_lifetime"]
 	if !ok {
 		t.Fatal("expected connection_max_lifetime in provider schema")
 	}
-	if s.Default != 300 {
-		t.Errorf("expected connection_max_lifetime default=300, got %v", s.Default)
+	if s.Default != 0 {
+		t.Errorf("expected connection_max_lifetime default=0, got %v", s.Default)
 	}
 
 	s, ok = p.Schema["connection_max_idle_time"]
 	if !ok {
 		t.Fatal("expected connection_max_idle_time in provider schema")
 	}
-	if s.Default != 120 {
-		t.Errorf("expected connection_max_idle_time default=120, got %v", s.Default)
+	if s.Default != 0 {
+		t.Errorf("expected connection_max_idle_time default=0, got %v", s.Default)
 	}
 }
 

--- a/sql/registry.go
+++ b/sql/registry.go
@@ -19,10 +19,10 @@ type PoolConfig struct {
 
 func DefaultPoolConfig() PoolConfig {
 	return PoolConfig{
-		MaxOpenConnections:    10,
-		MaxIdleConnections:    10,
-		ConnectionMaxLifetime: 5 * time.Minute,
-		ConnectionMaxIdleTime: 2 * time.Minute,
+		MaxOpenConnections:    0,
+		MaxIdleConnections:    2,
+		ConnectionMaxLifetime: 0,
+		ConnectionMaxIdleTime: 0,
 	}
 }
 

--- a/sql/registry.go
+++ b/sql/registry.go
@@ -1,0 +1,165 @@
+package sql
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PoolConfig struct {
+	MaxOpenConnections    int
+	MaxIdleConnections    int
+	ConnectionMaxLifetime time.Duration
+	ConnectionMaxIdleTime time.Duration
+}
+
+func DefaultPoolConfig() PoolConfig {
+	return PoolConfig{
+		MaxOpenConnections:    10,
+		MaxIdleConnections:    10,
+		ConnectionMaxLifetime: 5 * time.Minute,
+		ConnectionMaxIdleTime: 2 * time.Minute,
+	}
+}
+
+type RegistryKey struct {
+	Host           string
+	Port           string
+	Database       string
+	CredentialHash string
+}
+
+type ConnectionRegistry struct {
+	mu     sync.Mutex
+	pools  map[RegistryKey]*sql.DB
+	config PoolConfig
+	opener DBOpener
+}
+
+type DBOpener interface {
+	OpenDB(connector driver.Connector) *sql.DB
+}
+
+type defaultDBOpener struct{}
+
+func (d *defaultDBOpener) OpenDB(connector driver.Connector) *sql.DB {
+	return sql.OpenDB(connector)
+}
+
+func NewConnectionRegistry(config PoolConfig) *ConnectionRegistry {
+	return &ConnectionRegistry{
+		pools:  make(map[RegistryKey]*sql.DB),
+		config: config,
+		opener: &defaultDBOpener{},
+	}
+}
+
+func NewConnectionRegistryWithOpener(config PoolConfig, opener DBOpener) *ConnectionRegistry {
+	return &ConnectionRegistry{
+		pools:  make(map[RegistryKey]*sql.DB),
+		config: config,
+		opener: opener,
+	}
+}
+
+// Get returns a cached *sql.DB for the given key and connector, or creates and caches a new one.
+// The lock is held during connection creation to prevent duplicate connections for the same key.
+func (r *ConnectionRegistry) Get(key RegistryKey, connector driver.Connector, timeout time.Duration) (*sql.DB, error) {
+	r.mu.Lock()
+	if db, ok := r.pools[key]; ok {
+		r.mu.Unlock()
+		return db, nil
+	}
+
+	db, err := r.openWithRetry(connector, timeout)
+	if err != nil {
+		r.mu.Unlock()
+		return nil, err
+	}
+
+	r.applyPoolConfig(db)
+	r.pools[key] = db
+	r.mu.Unlock()
+	return db, nil
+}
+
+// Close closes all pooled connections and clears the registry.
+func (r *ConnectionRegistry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var lastErr error
+	for key, db := range r.pools {
+		if err := db.Close(); err != nil {
+			lastErr = err
+		}
+		delete(r.pools, key)
+	}
+	return lastErr
+}
+
+func (r *ConnectionRegistry) Size() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.pools)
+}
+
+func (r *ConnectionRegistry) Config() PoolConfig {
+	return r.config
+}
+
+func (r *ConnectionRegistry) applyPoolConfig(db *sql.DB) {
+	db.SetMaxOpenConns(r.config.MaxOpenConnections)
+	db.SetMaxIdleConns(r.config.MaxIdleConnections)
+	db.SetConnMaxLifetime(r.config.ConnectionMaxLifetime)
+	db.SetConnMaxIdleTime(r.config.ConnectionMaxIdleTime)
+}
+
+func (r *ConnectionRegistry) openWithRetry(connector driver.Connector, timeout time.Duration) (*sql.DB, error) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	timeoutExceeded := time.After(timeout)
+	for {
+		select {
+		case <-timeoutExceeded:
+			return nil, fmt.Errorf("db connection failed after %s timeout", timeout)
+
+		case <-ticker.C:
+			db := r.opener.OpenDB(connector)
+			if err := db.Ping(); err == nil {
+				return db, nil
+			} else {
+				db.Close()
+				errStr := err.Error()
+				if strings.Contains(strings.ToLower(errStr), "login failed") ||
+					strings.Contains(strings.ToLower(errStr), "login error") ||
+					strings.Contains(errStr, "error retrieving access token") ||
+					strings.Contains(errStr, "AuthenticationFailedError") ||
+					strings.Contains(errStr, "credential") ||
+					strings.Contains(errStr, "request failed") {
+					return nil, err
+				}
+			}
+		}
+	}
+}
+
+func MakeRegistryKey(host, port, database, username, password string) RegistryKey {
+	h := sha256.New()
+	h.Write([]byte(username))
+	h.Write([]byte(":"))
+	h.Write([]byte(password))
+	credHash := fmt.Sprintf("%x", h.Sum(nil))
+
+	return RegistryKey{
+		Host:           host,
+		Port:           port,
+		Database:       database,
+		CredentialHash: credHash,
+	}
+}

--- a/sql/registry_test.go
+++ b/sql/registry_test.go
@@ -1,0 +1,323 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type fakeConnector struct {
+	openCount atomic.Int64
+}
+
+func (f *fakeConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	f.openCount.Add(1)
+	return &fakeConn{}, nil
+}
+
+func (f *fakeConnector) Driver() driver.Driver {
+	return &fakeDriver{}
+}
+
+type fakeDriver struct{}
+
+func (d *fakeDriver) Open(name string) (driver.Conn, error) {
+	return &fakeConn{}, nil
+}
+
+type fakeConn struct{}
+
+func (c *fakeConn) Prepare(query string) (driver.Stmt, error) {
+	return &fakeStmt{}, nil
+}
+
+func (c *fakeConn) Close() error { return nil }
+
+func (c *fakeConn) Begin() (driver.Tx, error) {
+	return &fakeTx{}, nil
+}
+
+func (c *fakeConn) Ping(ctx context.Context) error { return nil }
+
+type fakeStmt struct{}
+
+func (s *fakeStmt) Close() error                                    { return nil }
+func (s *fakeStmt) NumInput() int                                   { return 0 }
+func (s *fakeStmt) Exec(args []driver.Value) (driver.Result, error) { return nil, nil }
+func (s *fakeStmt) Query(args []driver.Value) (driver.Rows, error)  { return nil, nil }
+
+type fakeTx struct{}
+
+func (t *fakeTx) Commit() error   { return nil }
+func (t *fakeTx) Rollback() error { return nil }
+
+type trackingDBOpener struct {
+	callCount atomic.Int64
+}
+
+func (o *trackingDBOpener) OpenDB(connector driver.Connector) *sql.DB {
+	o.callCount.Add(1)
+	return sql.OpenDB(connector)
+}
+
+func TestMakeRegistryKey_SameInputsSameKey(t *testing.T) {
+	key1 := MakeRegistryKey("host1", "1433", "mydb", "user", "pass")
+	key2 := MakeRegistryKey("host1", "1433", "mydb", "user", "pass")
+
+	if key1 != key2 {
+		t.Errorf("expected identical keys for same inputs, got %v and %v", key1, key2)
+	}
+}
+
+func TestMakeRegistryKey_DifferentInputsDifferentKey(t *testing.T) {
+	key1 := MakeRegistryKey("host1", "1433", "mydb", "user", "pass")
+	key2 := MakeRegistryKey("host1", "1433", "otherdb", "user", "pass")
+	key3 := MakeRegistryKey("host1", "1433", "mydb", "user", "differentpass")
+	key4 := MakeRegistryKey("host2", "1433", "mydb", "user", "pass")
+
+	if key1 == key2 {
+		t.Error("expected different keys for different databases")
+	}
+	if key1 == key3 {
+		t.Error("expected different keys for different credentials")
+	}
+	if key1 == key4 {
+		t.Error("expected different keys for different hosts")
+	}
+}
+
+func TestDefaultPoolConfig(t *testing.T) {
+	config := DefaultPoolConfig()
+
+	if config.MaxOpenConnections != 10 {
+		t.Errorf("expected MaxOpenConnections=10, got %d", config.MaxOpenConnections)
+	}
+	if config.MaxIdleConnections != 10 {
+		t.Errorf("expected MaxIdleConnections=10, got %d", config.MaxIdleConnections)
+	}
+	if config.ConnectionMaxLifetime != 5*time.Minute {
+		t.Errorf("expected ConnectionMaxLifetime=5m, got %v", config.ConnectionMaxLifetime)
+	}
+	if config.ConnectionMaxIdleTime != 2*time.Minute {
+		t.Errorf("expected ConnectionMaxIdleTime=2m, got %v", config.ConnectionMaxIdleTime)
+	}
+}
+
+func TestConnectionRegistry_GetReturnsSameInstance(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+	defer registry.Close()
+
+	connector := &fakeConnector{}
+	key := MakeRegistryKey("localhost", "1433", "testdb", "sa", "password")
+
+	db1, err := registry.Get(key, connector, 5*time.Second)
+	if err != nil {
+		t.Fatalf("first Get failed: %v", err)
+	}
+
+	db2, err := registry.Get(key, connector, 5*time.Second)
+	if err != nil {
+		t.Fatalf("second Get failed: %v", err)
+	}
+
+	if db1 != db2 {
+		t.Error("expected same *sql.DB instance for same key, got different instances")
+	}
+
+	if opener.callCount.Load() != 1 {
+		t.Errorf("expected OpenDB called once, got %d", opener.callCount.Load())
+	}
+}
+
+func TestConnectionRegistry_DifferentKeysReturnDifferentInstances(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+	defer registry.Close()
+
+	connector := &fakeConnector{}
+	key1 := MakeRegistryKey("localhost", "1433", "db1", "sa", "password")
+	key2 := MakeRegistryKey("localhost", "1433", "db2", "sa", "password")
+
+	db1, err := registry.Get(key1, connector, 5*time.Second)
+	if err != nil {
+		t.Fatalf("first Get failed: %v", err)
+	}
+
+	db2, err := registry.Get(key2, connector, 5*time.Second)
+	if err != nil {
+		t.Fatalf("second Get failed: %v", err)
+	}
+
+	if db1 == db2 {
+		t.Error("expected different *sql.DB instances for different keys")
+	}
+
+	if opener.callCount.Load() != 2 {
+		t.Errorf("expected OpenDB called twice, got %d", opener.callCount.Load())
+	}
+}
+
+func TestConnectionRegistry_Size(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+	defer registry.Close()
+
+	connector := &fakeConnector{}
+
+	if registry.Size() != 0 {
+		t.Errorf("expected size 0, got %d", registry.Size())
+	}
+
+	registry.Get(MakeRegistryKey("h", "1433", "db1", "u", "p"), connector, 5*time.Second)
+	if registry.Size() != 1 {
+		t.Errorf("expected size 1, got %d", registry.Size())
+	}
+
+	registry.Get(MakeRegistryKey("h", "1433", "db2", "u", "p"), connector, 5*time.Second)
+	if registry.Size() != 2 {
+		t.Errorf("expected size 2, got %d", registry.Size())
+	}
+
+	// Same key should not increase size
+	registry.Get(MakeRegistryKey("h", "1433", "db1", "u", "p"), connector, 5*time.Second)
+	if registry.Size() != 2 {
+		t.Errorf("expected size still 2, got %d", registry.Size())
+	}
+}
+
+func TestConnectionRegistry_Close(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+
+	connector := &fakeConnector{}
+	registry.Get(MakeRegistryKey("h", "1433", "db1", "u", "p"), connector, 5*time.Second)
+	registry.Get(MakeRegistryKey("h", "1433", "db2", "u", "p"), connector, 5*time.Second)
+
+	if registry.Size() != 2 {
+		t.Fatalf("expected size 2 before close, got %d", registry.Size())
+	}
+
+	err := registry.Close()
+	if err != nil {
+		t.Errorf("expected no error on close, got %v", err)
+	}
+
+	if registry.Size() != 0 {
+		t.Errorf("expected size 0 after close, got %d", registry.Size())
+	}
+}
+
+func TestConnectionRegistry_PoolConfigApplied(t *testing.T) {
+	config := PoolConfig{
+		MaxOpenConnections:    5,
+		MaxIdleConnections:    3,
+		ConnectionMaxLifetime: 10 * time.Minute,
+		ConnectionMaxIdleTime: 4 * time.Minute,
+	}
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(config, opener)
+	defer registry.Close()
+
+	connector := &fakeConnector{}
+	key := MakeRegistryKey("localhost", "1433", "testdb", "sa", "password")
+
+	db, err := registry.Get(key, connector, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	stats := db.Stats()
+	if stats.MaxOpenConnections != 5 {
+		t.Errorf("expected MaxOpenConnections=5, got %d", stats.MaxOpenConnections)
+	}
+
+	// Verify config is stored correctly
+	storedConfig := registry.Config()
+	if storedConfig.MaxOpenConnections != 5 {
+		t.Errorf("expected stored MaxOpenConnections=5, got %d", storedConfig.MaxOpenConnections)
+	}
+	if storedConfig.MaxIdleConnections != 3 {
+		t.Errorf("expected stored MaxIdleConnections=3, got %d", storedConfig.MaxIdleConnections)
+	}
+	if storedConfig.ConnectionMaxLifetime != 10*time.Minute {
+		t.Errorf("expected stored ConnectionMaxLifetime=10m, got %v", storedConfig.ConnectionMaxLifetime)
+	}
+	if storedConfig.ConnectionMaxIdleTime != 4*time.Minute {
+		t.Errorf("expected stored ConnectionMaxIdleTime=4m, got %v", storedConfig.ConnectionMaxIdleTime)
+	}
+}
+
+func TestConnectionRegistry_ConcurrentAccess(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+	defer registry.Close()
+
+	connector := &fakeConnector{}
+	key := MakeRegistryKey("localhost", "1433", "testdb", "sa", "password")
+
+	var wg sync.WaitGroup
+	results := make([]*sql.DB, 20)
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			db, err := registry.Get(key, connector, 5*time.Second)
+			if err != nil {
+				t.Errorf("goroutine %d: Get failed: %v", idx, err)
+				return
+			}
+			results[idx] = db
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All goroutines should have received the same *sql.DB instance
+	first := results[0]
+	for i, db := range results {
+		if db != first {
+			t.Errorf("goroutine %d got different *sql.DB instance", i)
+		}
+	}
+
+	// OpenDB should have been called exactly once since the lock is held during creation
+	if opener.callCount.Load() != 1 {
+		t.Errorf("expected OpenDB called once, got %d", opener.callCount.Load())
+	}
+}
+
+func TestConnectionRegistry_GetFailsOnConnectionError(t *testing.T) {
+	opener := &trackingDBOpener{}
+	registry := NewConnectionRegistryWithOpener(DefaultPoolConfig(), opener)
+	defer registry.Close()
+
+	failConnector := &failingConnector{}
+	key := MakeRegistryKey("unreachable", "1433", "testdb", "sa", "password")
+
+	_, err := registry.Get(key, failConnector, 1*time.Second)
+	if err == nil {
+		t.Error("expected error for unreachable host, got nil")
+	}
+
+	if registry.Size() != 0 {
+		t.Errorf("expected size 0 after failed connection, got %d", registry.Size())
+	}
+}
+
+type failingConnector struct{}
+
+func (f *failingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	return nil, &net.OpError{Op: "dial", Net: "tcp", Addr: nil, Err: fmt.Errorf("connection refused")}
+}
+
+func (f *failingConnector) Driver() driver.Driver {
+	return &fakeDriver{}
+}

--- a/sql/registry_test.go
+++ b/sql/registry_test.go
@@ -95,17 +95,17 @@ func TestMakeRegistryKey_DifferentInputsDifferentKey(t *testing.T) {
 func TestDefaultPoolConfig(t *testing.T) {
 	config := DefaultPoolConfig()
 
-	if config.MaxOpenConnections != 10 {
-		t.Errorf("expected MaxOpenConnections=10, got %d", config.MaxOpenConnections)
+	if config.MaxOpenConnections != 0 {
+		t.Errorf("expected MaxOpenConnections=0, got %d", config.MaxOpenConnections)
 	}
-	if config.MaxIdleConnections != 10 {
-		t.Errorf("expected MaxIdleConnections=10, got %d", config.MaxIdleConnections)
+	if config.MaxIdleConnections != 2 {
+		t.Errorf("expected MaxIdleConnections=2, got %d", config.MaxIdleConnections)
 	}
-	if config.ConnectionMaxLifetime != 5*time.Minute {
-		t.Errorf("expected ConnectionMaxLifetime=5m, got %v", config.ConnectionMaxLifetime)
+	if config.ConnectionMaxLifetime != 0 {
+		t.Errorf("expected ConnectionMaxLifetime=0, got %v", config.ConnectionMaxLifetime)
 	}
-	if config.ConnectionMaxIdleTime != 2*time.Minute {
-		t.Errorf("expected ConnectionMaxIdleTime=2m, got %v", config.ConnectionMaxIdleTime)
+	if config.ConnectionMaxIdleTime != 0 {
+		t.Errorf("expected ConnectionMaxIdleTime=0, got %v", config.ConnectionMaxIdleTime)
 	}
 }
 

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -19,265 +19,317 @@ import (
 	"github.com/pkg/errors"
 )
 
-type factory struct{}
-
-func GetFactory() model.ConnectorFactory {
-  return new(factory)
+type factory struct {
+	registry *ConnectionRegistry
 }
 
-func (f factory) GetConnector(prefix string, data *schema.ResourceData) (interface{}, error) {
-  if len(prefix) > 0 {
-    prefix = prefix + ".0."
-  }
+func GetFactory() model.ConnectorFactory {
+	return GetFactoryWithConfig(DefaultPoolConfig())
+}
 
-  connector := &Connector{
-    Host:    data.Get(prefix + "host").(string),
-    Port:    data.Get(prefix + "port").(string),
-    Timeout: data.Timeout(schema.TimeoutRead),
-  }
+func GetFactoryWithConfig(config PoolConfig) model.ConnectorFactory {
+	return &factory{
+		registry: NewConnectionRegistry(config),
+	}
+}
 
-  if admin, ok := data.GetOk(prefix + "login.0"); ok {
-    admin := admin.(map[string]interface{})
-    connector.Login = &LoginUser{
-      Username: admin["username"].(string),
-      Password: admin["password"].(string),
-    }
-  }
+func (f *factory) Registry() *ConnectionRegistry {
+	return f.registry
+}
 
-  if admin, ok := data.GetOk(prefix + "azure_login.0"); ok {
-    admin := admin.(map[string]interface{})
-    connector.AzureLogin = &AzureLogin{
-      TenantID:     admin["tenant_id"].(string),
-      ClientID:     admin["client_id"].(string),
-      ClientSecret: admin["client_secret"].(string),
-    }
-  }
+func ConfigureFactory(f model.ConnectorFactory, config PoolConfig) {
+	if sf, ok := f.(*factory); ok {
+		if sf.registry != nil {
+			sf.registry.Close()
+		}
+		sf.registry = NewConnectionRegistry(config)
+	}
+}
 
-  if admin, ok := data.GetOk(prefix + "azuread_managed_identity_auth.0"); ok {
-    admin := admin.(map[string]interface{})
-    connector.FedauthMSI = &FedauthMSI{
-      UserID: admin["user_id"].(string),
-    }
-  }
+func (f *factory) GetConnector(prefix string, data *schema.ResourceData) (interface{}, error) {
+	if len(prefix) > 0 {
+		prefix = prefix + ".0."
+	}
 
-  return connector, nil
+	connector := &Connector{
+		Host:     data.Get(prefix + "host").(string),
+		Port:     data.Get(prefix + "port").(string),
+		Timeout:  data.Timeout(schema.TimeoutRead),
+		registry: f.registry,
+	}
+
+	if admin, ok := data.GetOk(prefix + "login.0"); ok {
+		admin := admin.(map[string]interface{})
+		connector.Login = &LoginUser{
+			Username: admin["username"].(string),
+			Password: admin["password"].(string),
+		}
+	}
+
+	if admin, ok := data.GetOk(prefix + "azure_login.0"); ok {
+		admin := admin.(map[string]interface{})
+		connector.AzureLogin = &AzureLogin{
+			TenantID:     admin["tenant_id"].(string),
+			ClientID:     admin["client_id"].(string),
+			ClientSecret: admin["client_secret"].(string),
+		}
+	}
+
+	if admin, ok := data.GetOk(prefix + "azuread_managed_identity_auth.0"); ok {
+		admin := admin.(map[string]interface{})
+		connector.FedauthMSI = &FedauthMSI{
+			UserID: admin["user_id"].(string),
+		}
+	}
+
+	return connector, nil
 }
 
 type Connector struct {
-  Host       string `json:"host"`
-  Port       string `json:"port"`
-  Database   string `json:"database"`
-  Login      *LoginUser
-  AzureLogin *AzureLogin
-  FedauthMSI *FedauthMSI
-  Timeout    time.Duration `json:"timeout,omitempty"`
-  Token      string
+	Host       string `json:"host"`
+	Port       string `json:"port"`
+	Database   string `json:"database"`
+	Login      *LoginUser
+	AzureLogin *AzureLogin
+	FedauthMSI *FedauthMSI
+	Timeout    time.Duration `json:"timeout,omitempty"`
+	Token      string
+	registry   *ConnectionRegistry
 }
 
 type LoginUser struct {
-  Username string `json:"username,omitempty"`
-  Password string `json:"password,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
 }
 
 type AzureLogin struct {
-  TenantID     string `json:"tenant_id,omitempty"`
-  ClientID     string `json:"client_id,omitempty"`
-  ClientSecret string `json:"client_secret,omitempty"`
+	TenantID     string `json:"tenant_id,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
 }
 
 type FedauthMSI struct {
-  UserID string `json:"user_id,omitempty"`
+	UserID string `json:"user_id,omitempty"`
 }
 
 func (c *Connector) PingContext(ctx context.Context) error {
-  db, err := c.db()
-  if err != nil {
-    return err
-  }
+	db, err := c.db()
+	if err != nil {
+		return err
+	}
 
-  err = db.PingContext(ctx)
-  if err != nil {
-    return errors.Wrap(err, "In ping")
-  }
+	err = db.PingContext(ctx)
+	if err != nil {
+		return errors.Wrap(err, "In ping")
+	}
 
-  return nil
+	return nil
+}
+
+func (c *Connector) closeIfUnpooled(db *sql.DB) {
+	if c.registry == nil {
+		db.Close()
+	}
 }
 
 // Execute an SQL statement and ignore the results
 func (c *Connector) ExecContext(ctx context.Context, command string, args ...interface{}) error {
-  db, err := c.db()
-  if err != nil {
-    return err
-  }
-  defer db.Close()
+	db, err := c.db()
+	if err != nil {
+		return err
+	}
+	defer c.closeIfUnpooled(db)
 
-  _, err = db.ExecContext(ctx, command, args...)
-  if err != nil {
-    return err
-  }
+	_, err = db.ExecContext(ctx, command, args...)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 func (c *Connector) QueryContext(ctx context.Context, query string, scanner func(*sql.Rows) error, args ...interface{}) error {
-  db, err := c.db()
-  if err != nil {
-    return err
-  }
-  defer db.Close()
+	db, err := c.db()
+	if err != nil {
+		return err
+	}
+	defer c.closeIfUnpooled(db)
 
-  rows, err := db.QueryContext(ctx, query, args...)
-  if err != nil {
-    return err
-  }
-  defer rows.Close()
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
 
-  err = scanner(rows)
-  if err != nil {
-    return err
-  }
+	err = scanner(rows)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 func (c *Connector) QueryRowContext(ctx context.Context, query string, scanner func(*sql.Row) error, args ...interface{}) error {
-  db, err := c.db()
-  if err != nil {
-    return err
-  }
-  defer db.Close()
+	db, err := c.db()
+	if err != nil {
+		return err
+	}
+	defer c.closeIfUnpooled(db)
 
-  row := db.QueryRowContext(ctx, query, args...)
-  if row.Err() != nil {
-    return row.Err()
-  }
+	row := db.QueryRowContext(ctx, query, args...)
+	if row.Err() != nil {
+		return row.Err()
+	}
 
-  return scanner(row)
+	return scanner(row)
 }
 
 func (c *Connector) db() (*sql.DB, error) {
-  if c == nil {
-    panic("No connector")
-  }
-  conn, err := c.connector()
-  if err != nil {
-    return nil, err
-  }
-  if db, err := connectLoop(conn, c.Timeout); err != nil {
-    return nil, err
-  } else {
-    return db, nil
-  }
+	if c == nil {
+		panic("No connector")
+	}
+	conn, err := c.connector()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the connection registry if available (pooled mode)
+	if c.registry != nil {
+		key := c.registryKey()
+		return c.registry.Get(key, conn, c.Timeout)
+	}
+
+	// Fallback: no registry (unpooled mode)
+	if db, err := connectLoop(conn, c.Timeout); err != nil {
+		return nil, err
+	} else {
+		return db, nil
+	}
+}
+
+func (c *Connector) registryKey() RegistryKey {
+	username := ""
+	password := ""
+	if c.Login != nil {
+		username = c.Login.Username
+		password = c.Login.Password
+	} else if c.AzureLogin != nil {
+		username = c.AzureLogin.ClientID
+		password = c.AzureLogin.ClientSecret
+	} else if c.FedauthMSI != nil {
+		username = "msi:" + c.FedauthMSI.UserID
+	}
+	return MakeRegistryKey(c.Host, c.Port, c.Database, username, password)
 }
 
 func (c *Connector) connector() (driver.Connector, error) {
-  query := url.Values{}
-  host := fmt.Sprintf("%s:%s", c.Host, c.Port)
-  if c.Database != "" {
-    query.Set("database", c.Database)
-  }
-  if c.Login != nil || c.AzureLogin != nil {
-    connectionString := (&url.URL{
-      Scheme:   "sqlserver",
-      User:     c.userPassword(),
-      Host:     host,
-      RawQuery: query.Encode(),
-    }).String()
-    if c.Login != nil {
-        return mssql.NewConnector(connectionString)
-    }
-    return mssql.NewAccessTokenConnector(connectionString, func() (string, error) { return c.tokenProvider() })
-  }
-  if c.FedauthMSI != nil {
-    query.Set("fedauth", "ActiveDirectoryManagedIdentity")
-    if c.FedauthMSI.UserID != "" {
-      query.Set("user id", c.FedauthMSI.UserID)
-    }
-  } else {
-    query.Set("fedauth", "ActiveDirectoryDefault")
-  }
-  connectionString := (&url.URL{
-    Scheme:   "sqlserver",
-    Host:     host,
-    RawQuery: query.Encode(),
-  }).String()
-  return azuread.NewConnector(connectionString)
+	query := url.Values{}
+	host := fmt.Sprintf("%s:%s", c.Host, c.Port)
+	if c.Database != "" {
+		query.Set("database", c.Database)
+	}
+	if c.Login != nil || c.AzureLogin != nil {
+		connectionString := (&url.URL{
+			Scheme:   "sqlserver",
+			User:     c.userPassword(),
+			Host:     host,
+			RawQuery: query.Encode(),
+		}).String()
+		if c.Login != nil {
+			return mssql.NewConnector(connectionString)
+		}
+		return mssql.NewAccessTokenConnector(connectionString, func() (string, error) { return c.tokenProvider() })
+	}
+	if c.FedauthMSI != nil {
+		query.Set("fedauth", "ActiveDirectoryManagedIdentity")
+		if c.FedauthMSI.UserID != "" {
+			query.Set("user id", c.FedauthMSI.UserID)
+		}
+	} else {
+		query.Set("fedauth", "ActiveDirectoryDefault")
+	}
+	connectionString := (&url.URL{
+		Scheme:   "sqlserver",
+		Host:     host,
+		RawQuery: query.Encode(),
+	}).String()
+	return azuread.NewConnector(connectionString)
 }
 
 func (c *Connector) userPassword() *url.Userinfo {
-  if c.Login != nil {
-    return url.UserPassword(c.Login.Username, c.Login.Password)
-  }
-  return nil
+	if c.Login != nil {
+		return url.UserPassword(c.Login.Username, c.Login.Password)
+	}
+	return nil
 }
 
 func (c *Connector) tokenProvider() (string, error) {
-  const resourceID = "https://database.windows.net/"
+	const resourceID = "https://database.windows.net/"
 
-  admin := c.AzureLogin
-  oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, admin.TenantID)
-  if err != nil {
-    return "", err
-  }
+	admin := c.AzureLogin
+	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, admin.TenantID)
+	if err != nil {
+		return "", err
+	}
 
-  spt, err := adal.NewServicePrincipalToken(*oauthConfig, admin.ClientID, admin.ClientSecret, resourceID)
-  if err != nil {
-    return "", err
-  }
+	spt, err := adal.NewServicePrincipalToken(*oauthConfig, admin.ClientID, admin.ClientSecret, resourceID)
+	if err != nil {
+		return "", err
+	}
 
-  err = spt.EnsureFresh()
-  if err != nil {
-    return "", err
-  }
+	err = spt.EnsureFresh()
+	if err != nil {
+		return "", err
+	}
 
-  c.Token = spt.OAuthToken()
+	c.Token = spt.OAuthToken()
 
-  return spt.OAuthToken(), nil
+	return spt.OAuthToken(), nil
 }
 
 func connectLoop(connector driver.Connector, timeout time.Duration) (*sql.DB, error) {
-  ticker := time.NewTicker(250 * time.Millisecond)
-  defer ticker.Stop()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
 
-  timeoutExceeded := time.After(timeout)
-  for {
-    select {
-    case <-timeoutExceeded:
-      return nil, fmt.Errorf("db connection failed after %s timeout", timeout)
+	timeoutExceeded := time.After(timeout)
+	for {
+		select {
+		case <-timeoutExceeded:
+			return nil, fmt.Errorf("db connection failed after %s timeout", timeout)
 
-    case <-ticker.C:
-      db, err := connect(connector)
-      if err == nil {
-        return db, nil
-      }
-      if strings.Contains(strings.ToLower(err.Error()), "login failed") {
-        return nil, err
-      }
-      if strings.Contains(strings.ToLower(err.Error()), "login error") {
-        return nil, err
-      }
-      if strings.Contains(err.Error(), "error retrieving access token") {
-        return nil, err
-      }
-      if strings.Contains(err.Error(), "AuthenticationFailedError") {
-        return nil, err
-      }
-      if strings.Contains(err.Error(), "credential") {
-        return nil, err
-      }
-      if strings.Contains(err.Error(), "request failed") {
-        return nil, err
-      }
-      log.Println(errors.Wrap(err, "failed to connect to database"))
-    }
-  }
+		case <-ticker.C:
+			db, err := connect(connector)
+			if err == nil {
+				return db, nil
+			}
+			if strings.Contains(strings.ToLower(err.Error()), "login failed") {
+				return nil, err
+			}
+			if strings.Contains(strings.ToLower(err.Error()), "login error") {
+				return nil, err
+			}
+			if strings.Contains(err.Error(), "error retrieving access token") {
+				return nil, err
+			}
+			if strings.Contains(err.Error(), "AuthenticationFailedError") {
+				return nil, err
+			}
+			if strings.Contains(err.Error(), "credential") {
+				return nil, err
+			}
+			if strings.Contains(err.Error(), "request failed") {
+				return nil, err
+			}
+			log.Println(errors.Wrap(err, "failed to connect to database"))
+		}
+	}
 }
 
 func connect(connector driver.Connector) (*sql.DB, error) {
-  db := sql.OpenDB(connector)
-  if err := db.Ping(); err != nil {
-    db.Close()
-    return nil, err
-  }
-  return db, nil
+	db := sql.OpenDB(connector)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
 }


### PR DESCRIPTION
# Summary

In our Azure Hyperscale Elastic Pool we started running into issues when the number of managed resources increased. We started getting the following error during plans and state queries (with ~700 resources):

> The session limit for the database is 640 and has been reached. 
> For more information, see https://go.microsoft.com/fwlink/?linkid=2323004.

This seems to be related to an internal platform limit for the `master` database, which is used or login and queried for all resources.

With this PR I hope to introduce the option of enabling configurable connection pooling to better manage large numbers of resources to prevent this issue.

# Suggestion for changelog

## [0.4.0]

### Added

- Connection pooling via a connection registry that caches `*sql.DB` instances keyed by (host, port, database, credential hash). Connections are reused across resources targeting the same database, preventing session exhaustion during state refresh with large numbers of resources.
- Provider-level configuration attributes for pool tuning:
  - `max_open_connections` (default: `0`) — maximum number of open connections per database. `0` means unlimited.
  - `max_idle_connections` (default: `2`) — maximum number of idle connections retained per database.
  - `connection_max_lifetime` (default: `0`) — maximum time (in seconds) a connection may be reused. `0` means no limit.
  - `connection_max_idle_time` (default: `0`) — maximum time (in seconds) an idle connection is retained before being closed. `0` means no limit.

  These defaults match the Go `database/sql` package defaults and preserve the existing connection behaviour of previous provider versions, where connections were opened on demand without artificial limits.

### Fixed

- Session limit exhaustion ("The session limit for the database is X and has been reached") when managing large numbers of resources. Previously, each resource operation opened a new connection via `sql.OpenDB()` without reuse, causing hundreds of concurrent sessions against the master database during state refresh. The new connection registry ensures at most one `*sql.DB` per unique (server, database, credential) tuple.
